### PR TITLE
erasure_code: add LoongArch support

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -27,10 +27,12 @@ other_tests=
 other_tests_x86_64=
 other_tests_x86_32=
 other_tests_aarch64=
+other_tests_loongarch64=
 other_tests_ppc64le=
 lsrc_x86_64=
 lsrc_x86_32=
 lsrc_aarch64=
+lsrc_loongarch64=
 lsrc_ppc64le=
 lsrc_base_aliases=
 lsrc32=
@@ -71,6 +73,11 @@ endif
 if CPU_AARCH64
 libisal_la_SOURCES += ${lsrc_aarch64}
 other_tests += ${other_tests_aarch64}
+endif
+
+if CPU_LOONGARCH64
+libisal_la_SOURCES += ${lsrc_loongarch64}
+other_tests += ${other_tests_loongarch64}
 endif
 
 if CPU_PPC64LE
@@ -138,6 +145,10 @@ if CPU_AARCH64
   as_filter = $(CC) -D__ASSEMBLY__
 endif
 
+if CPU_LOONGARCH64
+  as_filter = $(CC) -D__ASSEMBLY__ -mlsx -mlasx -march=loongarch64
+endif
+
 CCAS = $(as_filter)
 EXTRA_DIST += tools/yasm-filter.sh tools/nasm-filter.sh
 EXTRA_DIST += tools/yasm-cet-filter.sh tools/nasm-cet-filter.sh
@@ -147,6 +158,11 @@ if CPU_AARCH64
 AM_CCASFLAGS = ${AM_CFLAGS}
 else
 AM_CCASFLAGS = ${yasm_args} ${INCLUDE} ${src_include} ${DEFS} ${D}
+endif
+
+if CPU_LOONGARCH64
+AM_CCASFLAGS = ${AM_CFLAGS}
+AM_CFLAGS += -DEC_ALIGNED_ADDR -mlsx -mlasx -march=loongarch64
 endif
 
 .asm.s:

--- a/configure.ac
+++ b/configure.ac
@@ -32,11 +32,13 @@ AS_CASE([$host_cpu],
   [arm64], [CPU="aarch64"],
   [powerpc64le], [CPU="ppc64le"],
   [ppc64le], [CPU="ppc64le"],
+  [loongarch64], [CPU="loongarch64"],
 )
 AM_CONDITIONAL([CPU_X86_64], [test "$CPU" = "x86_64"])
 AM_CONDITIONAL([CPU_X86_32], [test "$CPU" = "x86_32"])
 AM_CONDITIONAL([CPU_AARCH64], [test "$CPU" = "aarch64"])
 AM_CONDITIONAL([CPU_PPC64LE], [test "$CPU" = "ppc64le"])
+AM_CONDITIONAL([CPU_LOONGARCH64], [test "$CPU" = "loongarch64"])
 AM_CONDITIONAL([CPU_UNDEFINED], [test "x$CPU" = "x"])
 
 if test "$CPU" = "x86_64"; then

--- a/crc/Makefile.am
+++ b/crc/Makefile.am
@@ -36,6 +36,7 @@ lsrc  += \
 lsrc_base_aliases += crc/crc_base_aliases.c
 lsrc_x86_32       += crc/crc_base_aliases.c
 lsrc_ppc64le      += crc/crc_base_aliases.c
+lsrc_loongarch64  += crc/crc_base_aliases.c
 
 lsrc_x86_64 += \
 	crc/crc16_t10dif_01.asm \

--- a/erasure_code/Makefile.am
+++ b/erasure_code/Makefile.am
@@ -31,6 +31,8 @@ include erasure_code/aarch64/Makefile.am
 
 include erasure_code/ppc64le/Makefile.am
 
+include erasure_code/loongarch64/Makefile.am
+
 lsrc         += erasure_code/ec_base.c
 
 lsrc_base_aliases += erasure_code/ec_base_aliases.c

--- a/erasure_code/loongarch64/Makefile.am
+++ b/erasure_code/loongarch64/Makefile.am
@@ -1,0 +1,60 @@
+##################################################################
+#  Copyright (c) 2022 Loongson Technologies Co., Ltd.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions
+#  are met:
+#    * Redistributions of source code must retain the above copyright
+#      notice, this list of conditions and the following disclaimer.
+#    * Redistributions in binary form must reproduce the above copyright
+#      notice, this list of conditions and the following disclaimer in
+#      the documentation and/or other materials provided with the
+#      distribution.
+#    * Neither the name of Huawei Corporation nor the names of its
+#      contributors may be used to endorse or promote products derived
+#      from this software without specific prior written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+#  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+#  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+#  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+#  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+#  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+#  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+#  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+#  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+#  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+#  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+########################################################################
+
+lsrc_loongarch64 += \
+		erasure_code/loongarch64/gf_vect_dot_prod_lasx.c \
+		erasure_code/loongarch64/gf_2vect_dot_prod_lasx.c \
+		erasure_code/loongarch64/gf_3vect_dot_prod_lasx.c \
+		erasure_code/loongarch64/gf_4vect_dot_prod_lasx.c \
+		erasure_code/loongarch64/gf_5vect_dot_prod_lasx.c \
+		erasure_code/loongarch64/gf_6vect_dot_prod_lasx.c \
+		erasure_code/loongarch64/gf_vect_mad_lasx.c \
+		erasure_code/loongarch64/gf_2vect_mad_lasx.c \
+		erasure_code/loongarch64/gf_3vect_mad_lasx.c \
+		erasure_code/loongarch64/gf_4vect_mad_lasx.c \
+		erasure_code/loongarch64/gf_5vect_mad_lasx.c \
+		erasure_code/loongarch64/gf_6vect_mad_lasx.c \
+		erasure_code/loongarch64/gf_vect_mul_lasx.c \
+		erasure_code/loongarch64/ec_loongarch64_highlevel_func.c \
+		erasure_code/loongarch64/ec_loongarch64.c
+
+other_tests_loongarch64  += \
+		erasure_code/loongarch64/gf_vect_dot_prod_lasx_test \
+		erasure_code/loongarch64/gf_2vect_dot_prod_lasx_test \
+		erasure_code/loongarch64/gf_3vect_dot_prod_lasx_test \
+		erasure_code/loongarch64/gf_4vect_dot_prod_lasx_test \
+		erasure_code/loongarch64/gf_5vect_dot_prod_lasx_test \
+		erasure_code/loongarch64/gf_6vect_dot_prod_lasx_test \
+		erasure_code/loongarch64/gf_vect_mad_lasx_test \
+		erasure_code/loongarch64/gf_2vect_mad_lasx_test \
+		erasure_code/loongarch64/gf_3vect_mad_lasx_test \
+		erasure_code/loongarch64/gf_4vect_mad_lasx_test \
+		erasure_code/loongarch64/gf_5vect_mad_lasx_test \
+		erasure_code/loongarch64/gf_6vect_mad_lasx_test \
+		erasure_code/loongarch64/gf_vect_mul_lasx_test

--- a/erasure_code/loongarch64/ec_loongarch64.c
+++ b/erasure_code/loongarch64/ec_loongarch64.c
@@ -1,0 +1,61 @@
+/**********************************************************************
+  Copyright(c) 2022 Loongson Tech All rights reserved.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions
+  are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in
+      the documentation and/or other materials provided with the
+      distribution.
+    * Neither the name of Intel Corporation nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+**********************************************************************/
+
+#include "erasure_code.h"
+#include "ec_loongarch64.h"
+
+void gf_vect_dot_prod(int len, int vlen, unsigned char *v,
+		      unsigned char **src, unsigned char *dest)
+{
+	gf_vect_dot_prod_lasx(len, vlen, v, src, dest);
+}
+
+void gf_vect_mad(int len, int vec, int vec_i,
+		 unsigned char *v, unsigned char *src, unsigned char *dest)
+{
+	gf_vect_mad_lasx(len, vec, vec_i, v, src, dest);
+}
+
+void ec_encode_data(int len, int srcs, int dests, unsigned char *v,
+		    unsigned char **src, unsigned char **dest)
+{
+	ec_encode_data_lasx(len, srcs, dests, v, src, dest);
+}
+
+void ec_encode_data_update(int len, int k, int rows, int vec_i, unsigned char *v,
+			   unsigned char *data, unsigned char **dest)
+{
+	ec_encode_data_update_lasx(len, k, rows, vec_i, v, data, dest);
+}
+
+int gf_vect_mul(int len, unsigned char *a, void *src, void *dest)
+{
+	gf_vect_mul_lasx(len, a, (unsigned char *)src, (unsigned char *)dest);
+	return 0;
+}

--- a/erasure_code/loongarch64/ec_loongarch64.h
+++ b/erasure_code/loongarch64/ec_loongarch64.h
@@ -1,0 +1,74 @@
+/**********************************************************************
+  Copyright(c) 2022 Loongson Tech All rights reserved.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions
+  are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in
+      the documentation and/or other materials provided with the
+      distribution.
+    * Neither the name of Intel Corporation nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+**********************************************************************/
+
+void ec_encode_data_lasx(int len, int k, int rows, unsigned char *g_tbls,
+			 unsigned char **data, unsigned char **coding);
+
+void ec_encode_data_update_lasx(int len, int k, int rows, int vec_i,
+				unsigned char *g_tbls,
+				unsigned char *data, unsigned char **coding);
+
+void gf_vect_dot_prod_lasx(int len, int vlen, unsigned char *gftbls,
+			   unsigned char **src, unsigned char *dest);
+
+void gf_2vect_dot_prod_lasx(int len, int vlen, unsigned char *gftbls,
+			    unsigned char **src, unsigned char **dest);
+
+void gf_3vect_dot_prod_lasx(int len, int vlen, unsigned char *gftbls,
+			    unsigned char **src, unsigned char **dest);
+
+void gf_4vect_dot_prod_lasx(int len, int vlen, unsigned char *gftbls,
+			    unsigned char **src, unsigned char **dest);
+
+void gf_5vect_dot_prod_lasx(int len, int vlen, unsigned char *gftbls,
+			    unsigned char **src, unsigned char **dest);
+
+void gf_6vect_dot_prod_lasx(int len, int vlen, unsigned char *gftbls,
+			    unsigned char **src, unsigned char **dest);
+
+void gf_vect_mad_lasx(int len, int vec, int vec_i, unsigned char *gftbls,
+		      unsigned char *src, unsigned char *dest);
+
+void gf_2vect_mad_lasx(int len, int vec, int vec_i, unsigned char *gftbls,
+		       unsigned char *src, unsigned char **dest);
+
+void gf_3vect_mad_lasx(int len, int vec, int vec_i, unsigned char *gftbls,
+		       unsigned char *src, unsigned char **dest);
+
+void gf_4vect_mad_lasx(int len, int vec, int vec_i, unsigned char *gftbls,
+		       unsigned char *src, unsigned char **dest);
+
+void gf_5vect_mad_lasx(int len, int vec, int vec_i, unsigned char *gftbls,
+		       unsigned char *src, unsigned char **dest);
+
+void gf_6vect_mad_lasx(int len, int vec, int vec_i, unsigned char *gftbls,
+		       unsigned char *src, unsigned char **dest);
+
+int gf_vect_mul_lasx(int len, unsigned char *a, unsigned char *src,
+		     unsigned char *dest);

--- a/erasure_code/loongarch64/ec_loongarch64_highlevel_func.c
+++ b/erasure_code/loongarch64/ec_loongarch64_highlevel_func.c
@@ -1,0 +1,110 @@
+/**********************************************************************
+  Copyright(c) 2022 Loongson Tech All rights reserved.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions
+  are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in
+      the documentation and/or other materials provided with the
+      distribution.
+    * Neither the name of Intel Corporation nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+**********************************************************************/
+
+#include <limits.h>
+#include "erasure_code.h"
+#include "ec_loongarch64.h"
+
+void ec_encode_data_lasx(int len, int k, int rows, unsigned char *g_tbls,
+			 unsigned char **data, unsigned char **coding)
+{
+	if (len < 32) {
+		ec_encode_data_base(len, k, rows, g_tbls, data, coding);
+		return;
+	}
+
+	while (rows >= 6) {
+		gf_6vect_dot_prod_lasx(len, k, g_tbls, data, coding);
+		g_tbls += 6 * k * 32;
+		coding += 6;
+		rows -= 6;
+	}
+
+	switch (rows) {
+	case 5:
+		gf_5vect_dot_prod_lasx(len, k, g_tbls, data, coding);
+		break;
+	case 4:
+		gf_4vect_dot_prod_lasx(len, k, g_tbls, data, coding);
+		break;
+	case 3:
+		gf_3vect_dot_prod_lasx(len, k, g_tbls, data, coding);
+		break;
+	case 2:
+		gf_2vect_dot_prod_lasx(len, k, g_tbls, data, coding);
+		break;
+	case 1:
+		gf_vect_dot_prod_lasx(len, k, g_tbls, data, *coding);
+		break;
+	case 0:
+		break;
+	default:
+		break;
+	}
+}
+
+void ec_encode_data_update_lasx(int len, int k, int rows, int vec_i,
+				unsigned char *g_tbls,
+				unsigned char *data, unsigned char **coding)
+{
+	if (len < 32) {
+		ec_encode_data_update_base(len, k, rows, vec_i, g_tbls, data,
+					   coding);
+		return;
+	}
+
+	while (rows >= 6) {
+		gf_6vect_mad_lasx(len, k, vec_i, g_tbls, data, coding);
+		g_tbls += 6 * k * 32;
+		coding += 6;
+		rows -= 6;
+	}
+
+	switch (rows) {
+	case 5:
+		gf_5vect_mad_lasx(len, k, vec_i, g_tbls, data, coding);
+		break;
+	case 4:
+		gf_4vect_mad_lasx(len, k, vec_i, g_tbls, data, coding);
+		break;
+	case 3:
+		gf_3vect_mad_lasx(len, k, vec_i, g_tbls, data, coding);
+		break;
+	case 2:
+		gf_2vect_mad_lasx(len, k, vec_i, g_tbls, data, coding);
+		break;
+	case 1:
+		gf_vect_mad_lasx(len, k, vec_i, g_tbls, data, *coding);
+		break;
+	case 0:
+		break;
+	default:
+		break;
+	}
+}

--- a/erasure_code/loongarch64/gf_2vect_dot_prod_lasx.c
+++ b/erasure_code/loongarch64/gf_2vect_dot_prod_lasx.c
@@ -1,0 +1,168 @@
+/**********************************************************************
+  Copyright(c) 2022 Loongson Tech All rights reserved.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions
+  are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in
+      the documentation and/or other materials provided with the
+      distribution.
+    * Neither the name of Intel Corporation nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+**********************************************************************/
+
+#include <lasxintrin.h>
+
+void gf_2vect_dot_prod_lasx(int len, int vlen, unsigned char *gftbls,
+			    unsigned char **src, unsigned char **dest)
+{
+	int i, j, l;
+	int skip1 = vlen << 5;
+
+	int block_count = len >> 5;
+	int remain = len - (block_count << 5);
+	int buf_offset = 0, col_offset = 0;
+
+	__m256i block, high_idx, low_idx;
+	__m256i high_elem, low_elem;
+       	__m256i	high_val, low_val;
+	__m256i res1, res2;
+
+	unsigned long sul, index, tmp;
+	unsigned char *pos;
+	unsigned char suc, sval;
+
+	for (i = 0; i < block_count; ++i) {
+		res1 = __lasx_xvldi(0);
+		res2 = __lasx_xvldi(0);
+
+		buf_offset = i << 5;
+		for (j = 0; j < vlen; ++j) {
+			/* read one block from one buf to update two rows */
+
+			col_offset = j << 5;
+
+			// fetch one block from one buf into a vector variable,
+			// the block size is 32 bytes
+			block = __lasx_xvldx(src[j], buf_offset);
+
+			// get low indexes
+			low_idx = __lasx_xvandi_b(block, 0x0F);
+
+			// get high indexes: shift right 4 bits and add 0x10,
+			// which can index {0x10, ..., 0x1F}
+			high_idx = __lasx_xvori_b(__lasx_xvsrli_b(block, 4), 0x10);
+
+			/* =================== for row 0 =================== */
+			// fetch one element from gftbls, which is 32 bytes
+			low_elem = __lasx_xvldx(gftbls, col_offset);
+			high_elem = low_elem;
+
+			// duplicate low part
+			low_elem = __lasx_xvpermi_d(low_elem, 0x44);
+
+			// duplicate high part
+			high_elem = __lasx_xvpermi_d(high_elem, 0xEE);
+
+			// pick by low_idx
+			low_val = __lasx_xvshuf_b(low_elem, low_elem, low_idx);
+
+			// pick by high_idx
+			high_val = __lasx_xvshuf_b(high_elem, high_elem, high_idx);
+
+			// accumulation on GF(2^8)
+			res1 = __lasx_xvxor_v(res1, __lasx_xvxor_v(low_val, high_val));
+
+			/* =================== for row 1 =================== */
+			// fetch one element from gftbls, which is 32 bytes
+			low_elem = __lasx_xvldx(gftbls, col_offset + skip1);
+			high_elem = low_elem;
+
+			// duplicate low part
+			low_elem = __lasx_xvpermi_d(low_elem, 0x44);
+
+			// duplicate high part
+			high_elem = __lasx_xvpermi_d(high_elem, 0xEE);
+
+			// pick by low_idx
+			low_val = __lasx_xvshuf_b(low_elem, low_elem, low_idx);
+
+			// pick by high_idx
+			high_val = __lasx_xvshuf_b(high_elem, high_elem, high_idx);
+
+			// accumulation on GF(2^8)
+			res2 = __lasx_xvxor_v(res2, __lasx_xvxor_v(low_val, high_val));
+		}
+
+		__lasx_xvstx(res1, dest[0], buf_offset);
+		__lasx_xvstx(res2, dest[1], buf_offset);
+	}
+
+	if (remain == 0)
+		return;
+
+	// handle remain bytes
+	i = block_count << 5;
+	while (remain >= 8) {
+		for (l = 0; l < 2; ++l) {
+			sul = 0;
+			for (j = 0; j < vlen; ++j) {
+				index = *(unsigned long *)&src[j][i];
+				pos = &gftbls[(j << 5) + l * skip1];
+
+				tmp = pos[index & 0xF] ^ pos[16 + ((index >> 4) & 0xF)];
+				index = index >> 8;
+				tmp |= (unsigned long)(pos[index & 0xF] ^ pos[16 + ((index >> 4) & 0xF)]) << 8;
+				index = index >> 8;
+				tmp |= (unsigned long)(pos[index & 0xF] ^ pos[16 + ((index >> 4) & 0xF)]) << 16;
+				index = index >> 8;
+				tmp |= (unsigned long)(pos[index & 0xF] ^ pos[16 + ((index >> 4) & 0xF)]) << 24;
+				index = index >> 8;
+				tmp |= (unsigned long)(pos[index & 0xF] ^ pos[16 + ((index >> 4) & 0xF)]) << 32;
+				index = index >> 8;
+				tmp |= (unsigned long)(pos[index & 0xF] ^ pos[16 + ((index >> 4) & 0xF)]) << 40;
+				index = index >> 8;
+				tmp |= (unsigned long)(pos[index & 0xF] ^ pos[16 + ((index >> 4) & 0xF)]) << 48;
+				index = index >> 8;
+				tmp |= (unsigned long)(pos[index & 0xF] ^ pos[16 + ((index >> 4) & 0xF)]) << 56;
+
+				sul ^= tmp;
+			}
+			*(unsigned long *)&dest[l][i] = sul;
+		}
+		i += sizeof(unsigned long);
+		remain -= sizeof(unsigned long);
+	}
+
+	if (remain == 0)
+		return;
+
+	buf_offset = i;
+	for (l = 0; l < 2; l++) {
+		for (i = buf_offset; i < len; i++) {
+			suc = 0;
+			for (j = 0; j < vlen; j++) {
+				sval = src[j][i];
+				pos = &gftbls[(j << 5) + l * skip1];
+				suc ^= pos[sval & 0xF] ^ pos[16 + (sval >> 4)];
+			}
+			dest[l][i] = suc;
+		}
+	}
+}

--- a/erasure_code/loongarch64/gf_2vect_dot_prod_lasx_test.c
+++ b/erasure_code/loongarch64/gf_2vect_dot_prod_lasx_test.c
@@ -1,0 +1,481 @@
+/**********************************************************************
+  Copyright(c) 2011-2015 Intel Corporation All rights reserved.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions
+  are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in
+      the documentation and/or other materials provided with the
+      distribution.
+    * Neither the name of Intel Corporation nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+**********************************************************************/
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>		// for memset, memcmp
+#include "erasure_code.h"
+#include "ec_loongarch64.h"
+#include "types.h"
+
+#ifndef FUNCTION_UNDER_TEST
+# define FUNCTION_UNDER_TEST gf_2vect_dot_prod_lasx
+#endif
+#ifndef TEST_MIN_SIZE
+# define TEST_MIN_SIZE  16
+#endif
+
+#define str(s) #s
+#define xstr(s) str(s)
+
+#define TEST_LEN (8192+31)
+#define TEST_SIZE (TEST_LEN/2)
+#define TEST_MEM  TEST_SIZE
+#define TEST_LOOPS 10000
+#define TEST_TYPE_STR ""
+
+#ifndef TEST_SOURCES
+# define TEST_SOURCES  16
+#endif
+#ifndef RANDOMS
+# define RANDOMS 20
+#endif
+
+#ifdef EC_ALIGNED_ADDR
+// Define power of 2 range to check ptr, len alignment
+# define PTR_ALIGN_CHK_B 0
+# define LEN_ALIGN_CHK_B 0	// 0 for aligned only
+#else
+// Define power of 2 range to check ptr, len alignment
+# define PTR_ALIGN_CHK_B 32
+# define LEN_ALIGN_CHK_B 32	// 0 for aligned only
+#endif
+
+typedef unsigned char u8;
+
+extern void FUNCTION_UNDER_TEST(int len, int vlen, unsigned char *gftbls,
+				unsigned char **src, unsigned char **dest);
+
+void dump(unsigned char *buf, int len)
+{
+	int i;
+	for (i = 0; i < len;) {
+		printf(" %2x", 0xff & buf[i++]);
+		if (i % 32 == 0)
+			printf("\n");
+	}
+	printf("\n");
+}
+
+void dump_matrix(unsigned char **s, int k, int m)
+{
+	int i, j;
+	for (i = 0; i < k; i++) {
+		for (j = 0; j < m; j++) {
+			printf(" %2x", s[i][j]);
+		}
+		printf("\n");
+	}
+	printf("\n");
+}
+
+void dump_u8xu8(unsigned char *s, int k, int m)
+{
+	int i, j;
+	for (i = 0; i < k; i++) {
+		for (j = 0; j < m; j++) {
+			printf(" %2x", 0xff & s[j + (i * m)]);
+		}
+		printf("\n");
+	}
+	printf("\n");
+}
+
+int main(int argc, char *argv[])
+{
+	int i, j, rtest, srcs;
+	void *buf;
+	u8 g1[TEST_SOURCES], g2[TEST_SOURCES], g_tbls[2 * TEST_SOURCES * 32];
+	u8 *dest1, *dest2, *dest_ref1, *dest_ref2, *dest_ptrs[2];
+	u8 *buffs[TEST_SOURCES];
+
+	int align, size;
+	unsigned char *efence_buffs[TEST_SOURCES];
+	unsigned int offset;
+	u8 *ubuffs[TEST_SOURCES];
+	u8 *udest_ptrs[2];
+
+	printf(xstr(FUNCTION_UNDER_TEST) ": %dx%d ", TEST_SOURCES, TEST_LEN);
+
+	// Allocate the arrays
+	for (i = 0; i < TEST_SOURCES; i++) {
+		if (posix_memalign(&buf, 64, TEST_LEN)) {
+			printf("alloc error: Fail");
+			return -1;
+		}
+		buffs[i] = buf;
+	}
+
+	if (posix_memalign(&buf, 64, TEST_LEN)) {
+		printf("alloc error: Fail");
+		return -1;
+	}
+	dest1 = buf;
+
+	if (posix_memalign(&buf, 64, TEST_LEN)) {
+		printf("alloc error: Fail");
+		return -1;
+	}
+	dest2 = buf;
+
+	if (posix_memalign(&buf, 64, TEST_LEN)) {
+		printf("alloc error: Fail");
+		return -1;
+	}
+	dest_ref1 = buf;
+
+	if (posix_memalign(&buf, 64, TEST_LEN)) {
+		printf("alloc error: Fail");
+		return -1;
+	}
+	dest_ref2 = buf;
+
+	dest_ptrs[0] = dest1;
+	dest_ptrs[1] = dest2;
+
+	// Test of all zeros
+	for (i = 0; i < TEST_SOURCES; i++)
+		memset(buffs[i], 0, TEST_LEN);
+
+	memset(dest1, 0, TEST_LEN);
+	memset(dest2, 0, TEST_LEN);
+	memset(dest_ref1, 0, TEST_LEN);
+	memset(dest_ref2, 0, TEST_LEN);
+	memset(g1, 2, TEST_SOURCES);
+	memset(g2, 1, TEST_SOURCES);
+
+	for (i = 0; i < TEST_SOURCES; i++) {
+		gf_vect_mul_init(g1[i], &g_tbls[i * 32]);
+		gf_vect_mul_init(g2[i], &g_tbls[32 * TEST_SOURCES + i * 32]);
+	}
+
+	gf_vect_dot_prod_base(TEST_LEN, TEST_SOURCES, &g_tbls[0], buffs, dest_ref1);
+	gf_vect_dot_prod_base(TEST_LEN, TEST_SOURCES, &g_tbls[32 * TEST_SOURCES], buffs,
+			      dest_ref2);
+
+	FUNCTION_UNDER_TEST(TEST_LEN, TEST_SOURCES, g_tbls, buffs, dest_ptrs);
+
+	if (0 != memcmp(dest_ref1, dest1, TEST_LEN)) {
+		printf("Fail zero " xstr(FUNCTION_UNDER_TEST) " test1\n");
+		dump_matrix(buffs, 5, TEST_SOURCES);
+		printf("dprod_base:");
+		dump(dest_ref1, 25);
+		printf("dprod_dut:");
+		dump(dest1, 25);
+		return -1;
+	}
+	if (0 != memcmp(dest_ref2, dest2, TEST_LEN)) {
+		printf("Fail zero " xstr(FUNCTION_UNDER_TEST) " test2\n");
+		dump_matrix(buffs, 5, TEST_SOURCES);
+		printf("dprod_base:");
+		dump(dest_ref2, 25);
+		printf("dprod_dut:");
+		dump(dest2, 25);
+		return -1;
+	}
+
+	putchar('.');
+
+	// Rand data test
+
+	for (rtest = 0; rtest < RANDOMS; rtest++) {
+		for (i = 0; i < TEST_SOURCES; i++)
+			for (j = 0; j < TEST_LEN; j++)
+				buffs[i][j] = rand();
+
+		for (i = 0; i < TEST_SOURCES; i++) {
+			g1[i] = rand();
+			g2[i] = rand();
+		}
+
+		for (i = 0; i < TEST_SOURCES; i++) {
+			gf_vect_mul_init(g1[i], &g_tbls[i * 32]);
+			gf_vect_mul_init(g2[i], &g_tbls[(32 * TEST_SOURCES) + (i * 32)]);
+		}
+
+		gf_vect_dot_prod_base(TEST_LEN, TEST_SOURCES, &g_tbls[0], buffs, dest_ref1);
+		gf_vect_dot_prod_base(TEST_LEN, TEST_SOURCES, &g_tbls[32 * TEST_SOURCES],
+				      buffs, dest_ref2);
+
+		FUNCTION_UNDER_TEST(TEST_LEN, TEST_SOURCES, g_tbls, buffs, dest_ptrs);
+
+		if (0 != memcmp(dest_ref1, dest1, TEST_LEN)) {
+			printf("Fail rand " xstr(FUNCTION_UNDER_TEST) " test1 %d\n", rtest);
+			dump_matrix(buffs, 5, TEST_SOURCES);
+			printf("dprod_base:");
+			dump(dest_ref1, 25);
+			printf("dprod_dut:");
+			dump(dest1, 25);
+			return -1;
+		}
+		if (0 != memcmp(dest_ref2, dest2, TEST_LEN)) {
+			printf("Fail rand " xstr(FUNCTION_UNDER_TEST) " test2 %d\n", rtest);
+			dump_matrix(buffs, 5, TEST_SOURCES);
+			printf("dprod_base:");
+			dump(dest_ref2, 25);
+			printf("dprod_dut:");
+			dump(dest2, 25);
+			return -1;
+		}
+
+		putchar('.');
+	}
+
+	// Rand data test with varied parameters
+	for (rtest = 0; rtest < RANDOMS; rtest++) {
+		for (srcs = TEST_SOURCES; srcs > 0; srcs--) {
+			for (i = 0; i < srcs; i++)
+				for (j = 0; j < TEST_LEN; j++)
+					buffs[i][j] = rand();
+
+			for (i = 0; i < srcs; i++) {
+				g1[i] = rand();
+				g2[i] = rand();
+			}
+
+			for (i = 0; i < srcs; i++) {
+				gf_vect_mul_init(g1[i], &g_tbls[i * 32]);
+				gf_vect_mul_init(g2[i], &g_tbls[(32 * srcs) + (i * 32)]);
+			}
+
+			gf_vect_dot_prod_base(TEST_LEN, srcs, &g_tbls[0], buffs, dest_ref1);
+			gf_vect_dot_prod_base(TEST_LEN, srcs, &g_tbls[32 * srcs], buffs,
+					      dest_ref2);
+
+			FUNCTION_UNDER_TEST(TEST_LEN, srcs, g_tbls, buffs, dest_ptrs);
+
+			if (0 != memcmp(dest_ref1, dest1, TEST_LEN)) {
+				printf("Fail rand " xstr(FUNCTION_UNDER_TEST)
+				       " test1 srcs=%d\n", srcs);
+				dump_matrix(buffs, 5, TEST_SOURCES);
+				printf("dprod_base:");
+				dump(dest_ref1, 25);
+				printf("dprod_dut:");
+				dump(dest1, 25);
+				return -1;
+			}
+			if (0 != memcmp(dest_ref2, dest2, TEST_LEN)) {
+				printf("Fail rand " xstr(FUNCTION_UNDER_TEST)
+				       " test2 srcs=%d\n", srcs);
+				dump_matrix(buffs, 5, TEST_SOURCES);
+				printf("dprod_base:");
+				dump(dest_ref2, 25);
+				printf("dprod_dut:");
+				dump(dest2, 25);
+				return -1;
+			}
+
+			putchar('.');
+		}
+	}
+
+	// Run tests at end of buffer for Electric Fence
+	align = (LEN_ALIGN_CHK_B != 0) ? 1 : 16;
+	for (size = TEST_MIN_SIZE; size <= TEST_SIZE; size += align) {
+		for (i = 0; i < TEST_SOURCES; i++)
+			for (j = 0; j < TEST_LEN; j++)
+				buffs[i][j] = rand();
+
+		for (i = 0; i < TEST_SOURCES; i++)	// Line up TEST_SIZE from end
+			efence_buffs[i] = buffs[i] + TEST_LEN - size;
+
+		for (i = 0; i < TEST_SOURCES; i++) {
+			g1[i] = rand();
+			g2[i] = rand();
+		}
+
+		for (i = 0; i < TEST_SOURCES; i++) {
+			gf_vect_mul_init(g1[i], &g_tbls[i * 32]);
+			gf_vect_mul_init(g2[i], &g_tbls[(32 * TEST_SOURCES) + (i * 32)]);
+		}
+
+		gf_vect_dot_prod_base(size, TEST_SOURCES, &g_tbls[0], efence_buffs, dest_ref1);
+		gf_vect_dot_prod_base(size, TEST_SOURCES, &g_tbls[32 * TEST_SOURCES],
+				      efence_buffs, dest_ref2);
+
+		FUNCTION_UNDER_TEST(size, TEST_SOURCES, g_tbls, efence_buffs, dest_ptrs);
+
+		if (0 != memcmp(dest_ref1, dest1, size)) {
+			printf("Fail rand " xstr(FUNCTION_UNDER_TEST) " test1 %d\n", rtest);
+			dump_matrix(efence_buffs, 5, TEST_SOURCES);
+			printf("dprod_base:");
+			dump(dest_ref1, align);
+			printf("dprod_dut:");
+			dump(dest1, align);
+			return -1;
+		}
+
+		if (0 != memcmp(dest_ref2, dest2, size)) {
+			printf("Fail rand " xstr(FUNCTION_UNDER_TEST) " test2 %d\n", rtest);
+			dump_matrix(efence_buffs, 5, TEST_SOURCES);
+			printf("dprod_base:");
+			dump(dest_ref2, align);
+			printf("dprod_dut:");
+			dump(dest2, align);
+			return -1;
+		}
+
+		putchar('.');
+	}
+
+	// Test rand ptr alignment if available
+
+	for (rtest = 0; rtest < RANDOMS; rtest++) {
+		size = (TEST_LEN - PTR_ALIGN_CHK_B) & ~(TEST_MIN_SIZE - 1);
+		srcs = rand() % TEST_SOURCES;
+		if (srcs == 0)
+			continue;
+
+		offset = (PTR_ALIGN_CHK_B != 0) ? 1 : PTR_ALIGN_CHK_B;
+		// Add random offsets
+		for (i = 0; i < srcs; i++)
+			ubuffs[i] = buffs[i] + (rand() & (PTR_ALIGN_CHK_B - offset));
+
+		udest_ptrs[0] = dest1 + (rand() & (PTR_ALIGN_CHK_B - offset));
+		udest_ptrs[1] = dest2 + (rand() & (PTR_ALIGN_CHK_B - offset));
+
+		memset(dest1, 0, TEST_LEN);	// zero pad to check write-over
+		memset(dest2, 0, TEST_LEN);
+
+		for (i = 0; i < srcs; i++)
+			for (j = 0; j < size; j++)
+				ubuffs[i][j] = rand();
+
+		for (i = 0; i < srcs; i++) {
+			g1[i] = rand();
+			g2[i] = rand();
+		}
+
+		for (i = 0; i < srcs; i++) {
+			gf_vect_mul_init(g1[i], &g_tbls[i * 32]);
+			gf_vect_mul_init(g2[i], &g_tbls[(32 * srcs) + (i * 32)]);
+		}
+
+		gf_vect_dot_prod_base(size, srcs, &g_tbls[0], ubuffs, dest_ref1);
+		gf_vect_dot_prod_base(size, srcs, &g_tbls[32 * srcs], ubuffs, dest_ref2);
+
+		FUNCTION_UNDER_TEST(size, srcs, g_tbls, ubuffs, udest_ptrs);
+
+		if (memcmp(dest_ref1, udest_ptrs[0], size)) {
+			printf("Fail rand " xstr(FUNCTION_UNDER_TEST) " test ualign srcs=%d\n",
+			       srcs);
+			dump_matrix(ubuffs, 5, TEST_SOURCES);
+			printf("dprod_base:");
+			dump(dest_ref1, 25);
+			printf("dprod_dut:");
+			dump(udest_ptrs[0], 25);
+			return -1;
+		}
+		if (memcmp(dest_ref2, udest_ptrs[1], size)) {
+			printf("Fail rand " xstr(FUNCTION_UNDER_TEST) " test ualign srcs=%d\n",
+			       srcs);
+			dump_matrix(ubuffs, 5, TEST_SOURCES);
+			printf("dprod_base:");
+			dump(dest_ref2, 25);
+			printf("dprod_dut:");
+			dump(udest_ptrs[1], 25);
+			return -1;
+		}
+		// Confirm that padding around dests is unchanged
+		memset(dest_ref1, 0, PTR_ALIGN_CHK_B);	// Make reference zero buff
+		offset = udest_ptrs[0] - dest1;
+
+		if (memcmp(dest1, dest_ref1, offset)) {
+			printf("Fail rand ualign pad1 start\n");
+			return -1;
+		}
+		if (memcmp(dest1 + offset + size, dest_ref1, PTR_ALIGN_CHK_B - offset)) {
+			printf("Fail rand ualign pad1 end\n");
+			return -1;
+		}
+
+		offset = udest_ptrs[1] - dest2;
+		if (memcmp(dest2, dest_ref1, offset)) {
+			printf("Fail rand ualign pad2 start\n");
+			return -1;
+		}
+		if (memcmp(dest2 + offset + size, dest_ref1, PTR_ALIGN_CHK_B - offset)) {
+			printf("Fail rand ualign pad2 end\n");
+			return -1;
+		}
+
+		putchar('.');
+	}
+
+	// Test all size alignment
+	align = (LEN_ALIGN_CHK_B != 0) ? 1 : 16;
+
+	for (size = TEST_LEN; size >= TEST_MIN_SIZE; size -= align) {
+		srcs = TEST_SOURCES;
+
+		for (i = 0; i < srcs; i++)
+			for (j = 0; j < size; j++)
+				buffs[i][j] = rand();
+
+		for (i = 0; i < srcs; i++) {
+			g1[i] = rand();
+			g2[i] = rand();
+		}
+
+		for (i = 0; i < srcs; i++) {
+			gf_vect_mul_init(g1[i], &g_tbls[i * 32]);
+			gf_vect_mul_init(g2[i], &g_tbls[(32 * srcs) + (i * 32)]);
+		}
+
+		gf_vect_dot_prod_base(size, srcs, &g_tbls[0], buffs, dest_ref1);
+		gf_vect_dot_prod_base(size, srcs, &g_tbls[32 * srcs], buffs, dest_ref2);
+
+		FUNCTION_UNDER_TEST(size, srcs, g_tbls, buffs, dest_ptrs);
+
+		if (memcmp(dest_ref1, dest_ptrs[0], size)) {
+			printf("Fail rand " xstr(FUNCTION_UNDER_TEST) " test ualign len=%d\n",
+			       size);
+			dump_matrix(buffs, 5, TEST_SOURCES);
+			printf("dprod_base:");
+			dump(dest_ref1, 25);
+			printf("dprod_dut:");
+			dump(dest_ptrs[0], 25);
+			return -1;
+		}
+		if (memcmp(dest_ref2, dest_ptrs[1], size)) {
+			printf("Fail rand " xstr(FUNCTION_UNDER_TEST) " test ualign len=%d\n",
+			       size);
+			dump_matrix(buffs, 5, TEST_SOURCES);
+			printf("dprod_base:");
+			dump(dest_ref2, 25);
+			printf("dprod_dut:");
+			dump(dest_ptrs[1], 25);
+			return -1;
+		}
+	}
+
+	printf("Pass\n");
+	return 0;
+
+}

--- a/erasure_code/loongarch64/gf_2vect_mad_lasx.c
+++ b/erasure_code/loongarch64/gf_2vect_mad_lasx.c
@@ -1,0 +1,163 @@
+/**********************************************************************
+  Copyright(c) 2022 Loongson Tech All rights reserved.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions
+  are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in
+      the documentation and/or other materials provided with the
+      distribution.
+    * Neither the name of Intel Corporation nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+**********************************************************************/
+
+#include <lasxintrin.h>
+
+void gf_2vect_mad_lasx(int len, int vec, int vec_i, unsigned char *gftbls,
+		       unsigned char *src, unsigned char **dest)
+{
+	int i, l;
+	int skip1 = vec << 5;
+
+	int block_count = len >> 5;
+	int remain = len - (block_count << 5);
+	int buf_offset = 0, col_offset = vec_i << 5;
+
+	__m256i block, high_idx, low_idx;
+	__m256i high_elem, low_elem;
+       	__m256i	high_val, low_val;
+	__m256i res;
+
+	unsigned long index, tmp, tmp1;
+	unsigned char *pos;
+	unsigned char sval;
+
+	for (i = 0; i < block_count; ++i) {
+		/* read one block from src to update two rows */
+
+		buf_offset = i << 5;
+		// fetch one block from one buf into a vector variable,
+		// the block size is 32 bytes
+		block = __lasx_xvldx(src, buf_offset);
+
+		// get low indexes
+		low_idx = __lasx_xvandi_b(block, 0x0F);
+
+		// get high indexes: shift right 4 bits and add 0x10,
+		// which can index {0x10, ..., 0x1F}
+		high_idx = __lasx_xvori_b(__lasx_xvsrli_b(block, 4), 0x10);
+
+		/* =================== for row 0 =================== */
+		// fetch one element from gftbls, which is 32 bytes
+		low_elem = __lasx_xvldx(gftbls, col_offset);
+		high_elem = low_elem;
+
+		// duplicate low part
+		low_elem = __lasx_xvpermi_d(low_elem, 0x44);
+
+		// duplicate high part
+		high_elem = __lasx_xvpermi_d(high_elem, 0xEE);
+
+		// pick by low_idx
+		low_val = __lasx_xvshuf_b(low_elem, low_elem, low_idx);
+
+		// pick by high_idx
+		high_val = __lasx_xvshuf_b(high_elem, high_elem, high_idx);
+
+		// load old data
+		res = __lasx_xvldx(dest[0], buf_offset);
+
+		// accumulation on GF(2^8)
+		res = __lasx_xvxor_v(res, __lasx_xvxor_v(low_val, high_val));
+
+		// store new data
+		__lasx_xvstx(res, dest[0], buf_offset);
+
+		/* =================== for row 1 =================== */
+		// fetch one element from gftbls, which is 32 bytes
+		low_elem = __lasx_xvldx(gftbls, col_offset + skip1);
+		high_elem = low_elem;
+
+		// duplicate low part
+		low_elem = __lasx_xvpermi_d(low_elem, 0x44);
+
+		// duplicate high part
+		high_elem = __lasx_xvpermi_d(high_elem, 0xEE);
+
+		// pick by low_idx
+		low_val = __lasx_xvshuf_b(low_elem, low_elem, low_idx);
+
+		// pick by high_idx
+		high_val = __lasx_xvshuf_b(high_elem, high_elem, high_idx);
+
+		// load old data
+		res = __lasx_xvldx(dest[1], buf_offset);
+
+		// accumulation on GF(2^8)
+		res = __lasx_xvxor_v(res, __lasx_xvxor_v(low_val, high_val));
+
+		// store new data
+		__lasx_xvstx(res, dest[1], buf_offset);
+	}
+
+	if (remain == 0)
+		return;
+
+	// handle remain bytes
+	i = block_count << 5;
+	while (remain >= 8) {
+		tmp1 = *(unsigned long *)&src[i];
+		for (l = 0; l < 2; ++l) {
+			index = tmp1;
+			pos = &gftbls[col_offset + l * skip1];
+
+			tmp = pos[index & 0xF] ^ pos[16 + ((index >> 4) & 0xF)];
+			index = index >> 8;
+			tmp |= (unsigned long)(pos[index & 0xF] ^ pos[16 + ((index >> 4) & 0xF)]) << 8;
+			index = index >> 8;
+			tmp |= (unsigned long)(pos[index & 0xF] ^ pos[16 + ((index >> 4) & 0xF)]) << 16;
+			index = index >> 8;
+			tmp |= (unsigned long)(pos[index & 0xF] ^ pos[16 + ((index >> 4) & 0xF)]) << 24;
+			index = index >> 8;
+			tmp |= (unsigned long)(pos[index & 0xF] ^ pos[16 + ((index >> 4) & 0xF)]) << 32;
+			index = index >> 8;
+			tmp |= (unsigned long)(pos[index & 0xF] ^ pos[16 + ((index >> 4) & 0xF)]) << 40;
+			index = index >> 8;
+			tmp |= (unsigned long)(pos[index & 0xF] ^ pos[16 + ((index >> 4) & 0xF)]) << 48;
+			index = index >> 8;
+			tmp |= (unsigned long)(pos[index & 0xF] ^ pos[16 + ((index >> 4) & 0xF)]) << 56;
+
+			*(unsigned long *)&dest[l][i] ^= tmp;
+		}
+		i += sizeof(unsigned long);
+		remain -= sizeof(unsigned long);
+	}
+
+	if (remain == 0)
+		return;
+
+	buf_offset = i;
+	for (l = 0; l < 2; l++) {
+		for (i = buf_offset; i < len; i++) {
+			sval = src[i];
+			pos = &gftbls[col_offset + l * skip1];
+			dest[l][i] ^= pos[sval & 0xF] ^ pos[16 + (sval >> 4)];
+		}
+	}
+}

--- a/erasure_code/loongarch64/gf_2vect_mad_lasx_test.c
+++ b/erasure_code/loongarch64/gf_2vect_mad_lasx_test.c
@@ -1,0 +1,519 @@
+/**********************************************************************
+  Copyright(c) 2011-2015 Intel Corporation All rights reserved.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions
+  are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in
+      the documentation and/or other materials provided with the
+      distribution.
+    * Neither the name of Intel Corporation nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+**********************************************************************/
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>		// for memset, memcmp
+#include "erasure_code.h"
+#include "types.h"
+
+#ifndef ALIGN_SIZE
+# define ALIGN_SIZE 32
+#endif
+
+#ifndef FUNCTION_UNDER_TEST
+//By default, test multi-binary version
+# define FUNCTION_UNDER_TEST gf_2vect_mad_lasx
+# define REF_FUNCTION gf_2vect_dot_prod_lasx
+# define VECT 2
+#endif
+
+#ifndef TEST_MIN_SIZE
+# define TEST_MIN_SIZE 64
+#endif
+
+#define str(s) #s
+#define xstr(s) str(s)
+
+#define TEST_LEN (8192+31)
+#define TEST_SIZE (TEST_LEN/2)
+#define TEST_MEM  TEST_SIZE
+#define TEST_LOOPS 20000
+#define TEST_TYPE_STR ""
+
+#ifndef TEST_SOURCES
+# define TEST_SOURCES  16
+#endif
+#ifndef RANDOMS
+# define RANDOMS 20
+#endif
+
+#ifdef EC_ALIGNED_ADDR
+// Define power of 2 range to check ptr, len alignment
+# define PTR_ALIGN_CHK_B 0
+# define LEN_ALIGN_CHK_B 0	// 0 for aligned only
+#else
+// Define power of 2 range to check ptr, len alignment
+# define PTR_ALIGN_CHK_B ALIGN_SIZE
+# define LEN_ALIGN_CHK_B ALIGN_SIZE	// 0 for aligned only
+#endif
+
+#define str(s) #s
+#define xstr(s) str(s)
+
+typedef unsigned char u8;
+
+#if (VECT == 1)
+# define LAST_ARG *dest
+#else
+# define LAST_ARG **dest
+#endif
+
+extern void FUNCTION_UNDER_TEST(int len, int vec, int vec_i, unsigned char *gftbls,
+				unsigned char *src, unsigned char LAST_ARG);
+extern void REF_FUNCTION(int len, int vlen, unsigned char *gftbls, unsigned char **src,
+			 unsigned char LAST_ARG);
+
+void dump(unsigned char *buf, int len)
+{
+	int i;
+	for (i = 0; i < len;) {
+		printf(" %2x", 0xff & buf[i++]);
+		if (i % 32 == 0)
+			printf("\n");
+	}
+	printf("\n");
+}
+
+void dump_matrix(unsigned char **s, int k, int m)
+{
+	int i, j;
+	for (i = 0; i < k; i++) {
+		for (j = 0; j < m; j++) {
+			printf(" %2x", s[i][j]);
+		}
+		printf("\n");
+	}
+	printf("\n");
+}
+
+void dump_u8xu8(unsigned char *s, int k, int m)
+{
+	int i, j;
+	for (i = 0; i < k; i++) {
+		for (j = 0; j < m; j++) {
+			printf(" %2x", 0xff & s[j + (i * m)]);
+		}
+		printf("\n");
+	}
+	printf("\n");
+}
+
+int main(int argc, char *argv[])
+{
+	int i, j, rtest, srcs;
+	void *buf;
+	u8 gf[6][TEST_SOURCES];
+	u8 *g_tbls;
+	u8 *dest_ref[VECT];
+	u8 *dest_ptrs[VECT], *buffs[TEST_SOURCES];
+	int vector = VECT;
+
+	int align, size;
+	unsigned char *efence_buffs[TEST_SOURCES];
+	unsigned int offset;
+	u8 *ubuffs[TEST_SOURCES];
+	u8 *udest_ptrs[VECT];
+	printf("test" xstr(FUNCTION_UNDER_TEST) ": %dx%d ", TEST_SOURCES, TEST_LEN);
+
+	// Allocate the arrays
+	for (i = 0; i < TEST_SOURCES; i++) {
+		if (posix_memalign(&buf, 64, TEST_LEN)) {
+			printf("alloc error: Fail");
+			return -1;
+		}
+		buffs[i] = buf;
+	}
+
+	if (posix_memalign(&buf, 16, 2 * (vector * TEST_SOURCES * 32))) {
+		printf("alloc error: Fail");
+		return -1;
+	}
+	g_tbls = buf;
+
+	for (i = 0; i < vector; i++) {
+		if (posix_memalign(&buf, 64, TEST_LEN)) {
+			printf("alloc error: Fail");
+			return -1;
+		}
+		dest_ptrs[i] = buf;
+		memset(dest_ptrs[i], 0, TEST_LEN);
+	}
+
+	for (i = 0; i < vector; i++) {
+		if (posix_memalign(&buf, 64, TEST_LEN)) {
+			printf("alloc error: Fail");
+			return -1;
+		}
+		dest_ref[i] = buf;
+		memset(dest_ref[i], 0, TEST_LEN);
+	}
+
+	// Test of all zeros
+	for (i = 0; i < TEST_SOURCES; i++)
+		memset(buffs[i], 0, TEST_LEN);
+
+	switch (vector) {
+	case 6:
+		memset(gf[5], 0xe6, TEST_SOURCES);
+	case 5:
+		memset(gf[4], 4, TEST_SOURCES);
+	case 4:
+		memset(gf[3], 9, TEST_SOURCES);
+	case 3:
+		memset(gf[2], 7, TEST_SOURCES);
+	case 2:
+		memset(gf[1], 1, TEST_SOURCES);
+	case 1:
+		memset(gf[0], 2, TEST_SOURCES);
+		break;
+	default:
+		return -1;
+	}
+
+	for (i = 0; i < TEST_SOURCES; i++)
+		for (j = 0; j < TEST_LEN; j++)
+			buffs[i][j] = rand();
+
+	for (i = 0; i < vector; i++)
+		for (j = 0; j < TEST_SOURCES; j++) {
+			gf[i][j] = rand();
+			gf_vect_mul_init(gf[i][j], &g_tbls[i * (32 * TEST_SOURCES) + j * 32]);
+		}
+
+	for (i = 0; i < vector; i++)
+		gf_vect_dot_prod_base(TEST_LEN, TEST_SOURCES, &g_tbls[i * 32 * TEST_SOURCES],
+				      buffs, dest_ref[i]);
+
+	for (i = 0; i < vector; i++)
+		memset(dest_ptrs[i], 0, TEST_LEN);
+	for (i = 0; i < TEST_SOURCES; i++) {
+#if (VECT == 1)
+		FUNCTION_UNDER_TEST(TEST_LEN, TEST_SOURCES, i, g_tbls, buffs[i], *dest_ptrs);
+#else
+		FUNCTION_UNDER_TEST(TEST_LEN, TEST_SOURCES, i, g_tbls, buffs[i], dest_ptrs);
+#endif
+	}
+	for (i = 0; i < vector; i++) {
+		if (0 != memcmp(dest_ref[i], dest_ptrs[i], TEST_LEN)) {
+			printf("Fail zero " xstr(FUNCTION_UNDER_TEST) " test%d\n", i);
+			dump_matrix(buffs, vector, TEST_SOURCES);
+			printf("dprod_base:");
+			dump(dest_ref[i], 25);
+			printf("dprod_dut:");
+			dump(dest_ptrs[i], 25);
+			return -1;
+		}
+	}
+
+#if (VECT == 1)
+	REF_FUNCTION(TEST_LEN, TEST_SOURCES, g_tbls, buffs, *dest_ref);
+#else
+	REF_FUNCTION(TEST_LEN, TEST_SOURCES, g_tbls, buffs, dest_ref);
+#endif
+	for (i = 0; i < vector; i++) {
+		if (0 != memcmp(dest_ref[i], dest_ptrs[i], TEST_LEN)) {
+			printf("Fail zero " xstr(FUNCTION_UNDER_TEST) " test%d\n", i);
+			dump_matrix(buffs, vector, TEST_SOURCES);
+			printf("dprod_base:");
+			dump(dest_ref[i], 25);
+			printf("dprod_dut:");
+			dump(dest_ptrs[i], 25);
+			return -1;
+		}
+	}
+
+	putchar('.');
+
+	// Rand data test
+
+	for (rtest = 0; rtest < RANDOMS; rtest++) {
+		for (i = 0; i < TEST_SOURCES; i++)
+			for (j = 0; j < TEST_LEN; j++)
+				buffs[i][j] = rand();
+
+		for (i = 0; i < vector; i++)
+			for (j = 0; j < TEST_SOURCES; j++) {
+				gf[i][j] = rand();
+				gf_vect_mul_init(gf[i][j],
+						 &g_tbls[i * (32 * TEST_SOURCES) + j * 32]);
+			}
+
+		for (i = 0; i < vector; i++)
+			gf_vect_dot_prod_base(TEST_LEN, TEST_SOURCES,
+					      &g_tbls[i * 32 * TEST_SOURCES], buffs,
+					      dest_ref[i]);
+
+		for (i = 0; i < vector; i++)
+			memset(dest_ptrs[i], 0, TEST_LEN);
+		for (i = 0; i < TEST_SOURCES; i++) {
+#if (VECT == 1)
+			FUNCTION_UNDER_TEST(TEST_LEN, TEST_SOURCES, i, g_tbls, buffs[i],
+					    *dest_ptrs);
+#else
+			FUNCTION_UNDER_TEST(TEST_LEN, TEST_SOURCES, i, g_tbls, buffs[i],
+					    dest_ptrs);
+#endif
+		}
+		for (i = 0; i < vector; i++) {
+			if (0 != memcmp(dest_ref[i], dest_ptrs[i], TEST_LEN)) {
+				printf("Fail rand " xstr(FUNCTION_UNDER_TEST) " test%d %d\n",
+				       i, rtest);
+				dump_matrix(buffs, vector, TEST_SOURCES);
+				printf("dprod_base:");
+				dump(dest_ref[i], 25);
+				printf("dprod_dut:");
+				dump(dest_ptrs[i], 25);
+				return -1;
+			}
+		}
+
+		putchar('.');
+	}
+
+	// Rand data test with varied parameters
+	for (rtest = 0; rtest < RANDOMS; rtest++) {
+		for (srcs = TEST_SOURCES; srcs > 0; srcs--) {
+			for (i = 0; i < srcs; i++)
+				for (j = 0; j < TEST_LEN; j++)
+					buffs[i][j] = rand();
+
+			for (i = 0; i < vector; i++)
+				for (j = 0; j < srcs; j++) {
+					gf[i][j] = rand();
+					gf_vect_mul_init(gf[i][j],
+							 &g_tbls[i * (32 * srcs) + j * 32]);
+				}
+
+			for (i = 0; i < vector; i++)
+				gf_vect_dot_prod_base(TEST_LEN, srcs, &g_tbls[i * 32 * srcs],
+						      buffs, dest_ref[i]);
+
+			for (i = 0; i < vector; i++)
+				memset(dest_ptrs[i], 0, TEST_LEN);
+			for (i = 0; i < srcs; i++) {
+#if (VECT == 1)
+				FUNCTION_UNDER_TEST(TEST_LEN, srcs, i, g_tbls, buffs[i],
+						    *dest_ptrs);
+#else
+				FUNCTION_UNDER_TEST(TEST_LEN, srcs, i, g_tbls, buffs[i],
+						    dest_ptrs);
+#endif
+
+			}
+			for (i = 0; i < vector; i++) {
+				if (0 != memcmp(dest_ref[i], dest_ptrs[i], TEST_LEN)) {
+					printf("Fail rand " xstr(FUNCTION_UNDER_TEST)
+					       " test%d srcs=%d\n", i, srcs);
+					dump_matrix(buffs, vector, TEST_SOURCES);
+					printf("dprod_base:");
+					dump(dest_ref[i], 25);
+					printf("dprod_dut:");
+					dump(dest_ptrs[i], 25);
+					return -1;
+				}
+			}
+
+			putchar('.');
+		}
+	}
+
+	// Run tests at end of buffer for Electric Fence
+	align = (LEN_ALIGN_CHK_B != 0) ? 1 : ALIGN_SIZE;
+	for (size = TEST_MIN_SIZE; size <= TEST_SIZE; size += align) {
+		for (i = 0; i < TEST_SOURCES; i++)
+			for (j = 0; j < TEST_LEN; j++)
+				buffs[i][j] = rand();
+
+		for (i = 0; i < TEST_SOURCES; i++)	// Line up TEST_SIZE from end
+			efence_buffs[i] = buffs[i] + TEST_LEN - size;
+
+		for (i = 0; i < vector; i++)
+			for (j = 0; j < TEST_SOURCES; j++) {
+				gf[i][j] = rand();
+				gf_vect_mul_init(gf[i][j],
+						 &g_tbls[i * (32 * TEST_SOURCES) + j * 32]);
+			}
+
+		for (i = 0; i < vector; i++)
+			gf_vect_dot_prod_base(size, TEST_SOURCES,
+					      &g_tbls[i * 32 * TEST_SOURCES], efence_buffs,
+					      dest_ref[i]);
+
+		for (i = 0; i < vector; i++)
+			memset(dest_ptrs[i], 0, size);
+		for (i = 0; i < TEST_SOURCES; i++) {
+#if (VECT == 1)
+			FUNCTION_UNDER_TEST(size, TEST_SOURCES, i, g_tbls, efence_buffs[i],
+					    *dest_ptrs);
+#else
+			FUNCTION_UNDER_TEST(size, TEST_SOURCES, i, g_tbls, efence_buffs[i],
+					    dest_ptrs);
+#endif
+		}
+		for (i = 0; i < vector; i++) {
+			if (0 != memcmp(dest_ref[i], dest_ptrs[i], size)) {
+				printf("Fail rand " xstr(FUNCTION_UNDER_TEST)
+				       " test%d size=%d\n", i, size);
+				dump_matrix(buffs, vector, TEST_SOURCES);
+				printf("dprod_base:");
+				dump(dest_ref[i], TEST_MIN_SIZE + align);
+				printf("dprod_dut:");
+				dump(dest_ptrs[i], TEST_MIN_SIZE + align);
+				return -1;
+			}
+		}
+
+		putchar('.');
+	}
+
+	// Test rand ptr alignment if available
+
+	for (rtest = 0; rtest < RANDOMS; rtest++) {
+		size = (TEST_LEN - PTR_ALIGN_CHK_B) & ~(TEST_MIN_SIZE - 1);
+		srcs = rand() % TEST_SOURCES;
+		if (srcs == 0)
+			continue;
+
+		offset = (PTR_ALIGN_CHK_B != 0) ? 1 : PTR_ALIGN_CHK_B;
+		// Add random offsets
+		for (i = 0; i < srcs; i++)
+			ubuffs[i] = buffs[i] + (rand() & (PTR_ALIGN_CHK_B - offset));
+
+		for (i = 0; i < vector; i++) {
+			udest_ptrs[i] = dest_ptrs[i] + (rand() & (PTR_ALIGN_CHK_B - offset));
+			memset(dest_ptrs[i], 0, TEST_LEN);	// zero pad to check write-over
+		}
+
+		for (i = 0; i < srcs; i++)
+			for (j = 0; j < size; j++)
+				ubuffs[i][j] = rand();
+
+		for (i = 0; i < vector; i++)
+			for (j = 0; j < srcs; j++) {
+				gf[i][j] = rand();
+				gf_vect_mul_init(gf[i][j], &g_tbls[i * (32 * srcs) + j * 32]);
+			}
+
+		for (i = 0; i < vector; i++)
+			gf_vect_dot_prod_base(size, srcs, &g_tbls[i * 32 * srcs], ubuffs,
+					      dest_ref[i]);
+
+		for (i = 0; i < srcs; i++) {
+#if (VECT == 1)
+			FUNCTION_UNDER_TEST(size, srcs, i, g_tbls, ubuffs[i], *udest_ptrs);
+#else
+			FUNCTION_UNDER_TEST(size, srcs, i, g_tbls, ubuffs[i], udest_ptrs);
+#endif
+		}
+		for (i = 0; i < vector; i++) {
+			if (0 != memcmp(dest_ref[i], udest_ptrs[i], size)) {
+				printf("Fail rand " xstr(FUNCTION_UNDER_TEST)
+				       " test%d ualign srcs=%d\n", i, srcs);
+				dump_matrix(buffs, vector, TEST_SOURCES);
+				printf("dprod_base:");
+				dump(dest_ref[i], 25);
+				printf("dprod_dut:");
+				dump(udest_ptrs[i], 25);
+				return -1;
+			}
+		}
+
+		// Confirm that padding around dests is unchanged
+		memset(dest_ref[0], 0, PTR_ALIGN_CHK_B);	// Make reference zero buff
+
+		for (i = 0; i < vector; i++) {
+			offset = udest_ptrs[i] - dest_ptrs[i];
+			if (memcmp(dest_ptrs[i], dest_ref[0], offset)) {
+				printf("Fail rand ualign pad1 start\n");
+				return -1;
+			}
+			if (memcmp
+			    (dest_ptrs[i] + offset + size, dest_ref[0],
+			     PTR_ALIGN_CHK_B - offset)) {
+				printf("Fail rand ualign pad1 end\n");
+				return -1;
+			}
+		}
+
+		putchar('.');
+	}
+
+	// Test all size alignment
+	align = (LEN_ALIGN_CHK_B != 0) ? 1 : ALIGN_SIZE;
+
+	for (size = TEST_LEN; size >= TEST_MIN_SIZE; size -= align) {
+		for (i = 0; i < TEST_SOURCES; i++)
+			for (j = 0; j < size; j++)
+				buffs[i][j] = rand();
+
+		for (i = 0; i < vector; i++) {
+			for (j = 0; j < TEST_SOURCES; j++) {
+				gf[i][j] = rand();
+				gf_vect_mul_init(gf[i][j],
+						 &g_tbls[i * (32 * TEST_SOURCES) + j * 32]);
+			}
+			memset(dest_ptrs[i], 0, TEST_LEN);	// zero pad to check write-over
+		}
+
+		for (i = 0; i < vector; i++)
+			gf_vect_dot_prod_base(size, TEST_SOURCES,
+					      &g_tbls[i * 32 * TEST_SOURCES], buffs,
+					      dest_ref[i]);
+
+		for (i = 0; i < TEST_SOURCES; i++) {
+#if (VECT == 1)
+			FUNCTION_UNDER_TEST(size, TEST_SOURCES, i, g_tbls, buffs[i],
+					    *dest_ptrs);
+#else
+			FUNCTION_UNDER_TEST(size, TEST_SOURCES, i, g_tbls, buffs[i],
+					    dest_ptrs);
+#endif
+		}
+		for (i = 0; i < vector; i++) {
+			if (0 != memcmp(dest_ref[i], dest_ptrs[i], size)) {
+				printf("Fail rand " xstr(FUNCTION_UNDER_TEST)
+				       " test%d ualign len=%d\n", i, size);
+				dump_matrix(buffs, vector, TEST_SOURCES);
+				printf("dprod_base:");
+				dump(dest_ref[i], 25);
+				printf("dprod_dut:");
+				dump(dest_ptrs[i], 25);
+				return -1;
+			}
+		}
+
+		putchar('.');
+
+	}
+
+	printf("Pass\n");
+	return 0;
+
+}

--- a/erasure_code/loongarch64/gf_3vect_dot_prod_lasx.c
+++ b/erasure_code/loongarch64/gf_3vect_dot_prod_lasx.c
@@ -1,0 +1,191 @@
+/**********************************************************************
+  Copyright(c) 2022 Loongson Tech All rights reserved.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions
+  are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in
+      the documentation and/or other materials provided with the
+      distribution.
+    * Neither the name of Intel Corporation nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+**********************************************************************/
+
+#include <lasxintrin.h>
+
+void gf_3vect_dot_prod_lasx(int len, int vlen, unsigned char *gftbls,
+			    unsigned char **src, unsigned char **dest)
+{
+	int i, j, l;
+	int skip1 = vlen << 5;
+	int skip2 = skip1 << 1;
+
+	int block_count = len >> 5;
+	int remain = len - (block_count << 5);
+	int buf_offset = 0, col_offset = 0;
+
+	__m256i block, high_idx, low_idx;
+	__m256i high_elem, low_elem;
+       	__m256i	high_val, low_val;
+	__m256i res1, res2, res3;
+
+	unsigned long sul, index, tmp;
+	unsigned char *pos;
+	unsigned char suc, sval;
+
+	for (i = 0; i < block_count; ++i) {
+		res1 = __lasx_xvldi(0);
+		res2 = __lasx_xvldi(0);
+		res3 = __lasx_xvldi(0);
+
+		buf_offset = i << 5;
+		for (j = 0; j < vlen; ++j) {
+			/* read one block from one buf to update three rows */
+
+			col_offset = j << 5;
+
+			// fetch one block from one buf into a vector variable,
+			// the block size is 32 bytes
+			block = __lasx_xvldx(src[j], buf_offset);
+
+			// get low indexes
+			low_idx = __lasx_xvandi_b(block, 0x0F);
+
+			// get high indexes: shift right 4 bits and add 0x10,
+			// which can index {0x10, ..., 0x1F}
+			high_idx = __lasx_xvori_b(__lasx_xvsrli_b(block, 4), 0x10);
+
+			/* =================== for row 0 =================== */
+			// fetch one element from gftbls, which is 32 bytes
+			low_elem = __lasx_xvldx(gftbls, col_offset);
+			high_elem = low_elem;
+
+			// duplicate low part
+			low_elem = __lasx_xvpermi_d(low_elem, 0x44);
+
+			// duplicate high part
+			high_elem = __lasx_xvpermi_d(high_elem, 0xEE);
+
+			// pick by low_idx
+			low_val = __lasx_xvshuf_b(low_elem, low_elem, low_idx);
+
+			// pick by high_idx
+			high_val = __lasx_xvshuf_b(high_elem, high_elem, high_idx);
+
+			// accumulation on GF(2^8)
+			res1 = __lasx_xvxor_v(res1, __lasx_xvxor_v(low_val, high_val));
+
+			/* =================== for row 1 =================== */
+			// fetch one element from gftbls, which is 32 bytes
+			low_elem = __lasx_xvldx(gftbls, col_offset + skip1);
+			high_elem = low_elem;
+
+			// duplicate low part
+			low_elem = __lasx_xvpermi_d(low_elem, 0x44);
+
+			// duplicate high part
+			high_elem = __lasx_xvpermi_d(high_elem, 0xEE);
+
+			// pick by low_idx
+			low_val = __lasx_xvshuf_b(low_elem, low_elem, low_idx);
+
+			// pick by high_idx
+			high_val = __lasx_xvshuf_b(high_elem, high_elem, high_idx);
+
+			// accumulation on GF(2^8)
+			res2 = __lasx_xvxor_v(res2, __lasx_xvxor_v(low_val, high_val));
+
+			/* =================== for row 2 =================== */
+			// fetch one element from gftbls, which is 32 bytes
+			low_elem = __lasx_xvldx(gftbls, col_offset + skip2);
+			high_elem = low_elem;
+
+			// duplicate low part
+			low_elem = __lasx_xvpermi_d(low_elem, 0x44);
+
+			// duplicate high part
+			high_elem = __lasx_xvpermi_d(high_elem, 0xEE);
+
+			// pick by low_idx
+			low_val = __lasx_xvshuf_b(low_elem, low_elem, low_idx);
+
+			// pick by high_idx
+			high_val = __lasx_xvshuf_b(high_elem, high_elem, high_idx);
+
+			// accumulation on GF(2^8)
+			res3 = __lasx_xvxor_v(res3, __lasx_xvxor_v(low_val, high_val));
+		}
+
+		__lasx_xvstx(res1, dest[0], buf_offset);
+		__lasx_xvstx(res2, dest[1], buf_offset);
+		__lasx_xvstx(res3, dest[2], buf_offset);
+	}
+
+	if (remain == 0)
+		return;
+
+	// handle remain bytes
+	i = block_count << 5;
+	while (remain >= 8) {
+		for (l = 0; l < 3; ++l) {
+			sul = 0;
+			for (j = 0; j < vlen; ++j) {
+				index = *(unsigned long *)&src[j][i];
+				pos = &gftbls[(j << 5) + l * skip1];
+
+				tmp = pos[index & 0xF] ^ pos[16 + ((index >> 4) & 0xF)];
+				index = index >> 8;
+				tmp |= (unsigned long)(pos[index & 0xF] ^ pos[16 + ((index >> 4) & 0xF)]) << 8;
+				index = index >> 8;
+				tmp |= (unsigned long)(pos[index & 0xF] ^ pos[16 + ((index >> 4) & 0xF)]) << 16;
+				index = index >> 8;
+				tmp |= (unsigned long)(pos[index & 0xF] ^ pos[16 + ((index >> 4) & 0xF)]) << 24;
+				index = index >> 8;
+				tmp |= (unsigned long)(pos[index & 0xF] ^ pos[16 + ((index >> 4) & 0xF)]) << 32;
+				index = index >> 8;
+				tmp |= (unsigned long)(pos[index & 0xF] ^ pos[16 + ((index >> 4) & 0xF)]) << 40;
+				index = index >> 8;
+				tmp |= (unsigned long)(pos[index & 0xF] ^ pos[16 + ((index >> 4) & 0xF)]) << 48;
+				index = index >> 8;
+				tmp |= (unsigned long)(pos[index & 0xF] ^ pos[16 + ((index >> 4) & 0xF)]) << 56;
+
+				sul ^= tmp;
+			}
+			*(unsigned long *)&dest[l][i] = sul;
+		}
+		i += sizeof(unsigned long);
+		remain -= sizeof(unsigned long);
+	}
+
+	if (remain == 0)
+		return;
+
+	buf_offset = i;
+	for (l = 0; l < 3; l++) {
+		for (i = buf_offset; i < len; i++) {
+			suc = 0;
+			for (j = 0; j < vlen; j++) {
+				sval = src[j][i];
+				pos = &gftbls[(j << 5) + l * skip1];
+				suc ^= pos[sval & 0xF] ^ pos[16 + (sval >> 4)];
+			}
+			dest[l][i] = suc;
+		}
+	}
+}

--- a/erasure_code/loongarch64/gf_3vect_dot_prod_lasx_test.c
+++ b/erasure_code/loongarch64/gf_3vect_dot_prod_lasx_test.c
@@ -1,0 +1,587 @@
+/**********************************************************************
+  Copyright(c) 2011-2015 Intel Corporation All rights reserved.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions
+  are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in
+      the documentation and/or other materials provided with the
+      distribution.
+    * Neither the name of Intel Corporation nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+**********************************************************************/
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>		// for memset, memcmp
+#include "erasure_code.h"
+#include "ec_loongarch64.h"
+#include "types.h"
+
+#ifndef FUNCTION_UNDER_TEST
+# define FUNCTION_UNDER_TEST gf_3vect_dot_prod_lasx
+#endif
+#ifndef TEST_MIN_SIZE
+# define TEST_MIN_SIZE  16
+#endif
+
+#define str(s) #s
+#define xstr(s) str(s)
+
+#define TEST_LEN (8192+31)
+#define TEST_SIZE (TEST_LEN/2)
+#define TEST_MEM  TEST_SIZE
+#define TEST_LOOPS 10000
+#define TEST_TYPE_STR ""
+
+#ifndef TEST_SOURCES
+# define TEST_SOURCES  16
+#endif
+#ifndef RANDOMS
+# define RANDOMS 20
+#endif
+
+#ifdef EC_ALIGNED_ADDR
+// Define power of 2 range to check ptr, len alignment
+# define PTR_ALIGN_CHK_B 0
+# define LEN_ALIGN_CHK_B 0	// 0 for aligned only
+#else
+// Define power of 2 range to check ptr, len alignment
+# define PTR_ALIGN_CHK_B 32
+# define LEN_ALIGN_CHK_B 32	// 0 for aligned only
+#endif
+
+typedef unsigned char u8;
+
+extern void FUNCTION_UNDER_TEST(int len, int vlen, unsigned char *gftbls,
+				unsigned char **src, unsigned char **dest);
+
+void dump(unsigned char *buf, int len)
+{
+	int i;
+	for (i = 0; i < len;) {
+		printf(" %2x", 0xff & buf[i++]);
+		if (i % 32 == 0)
+			printf("\n");
+	}
+	printf("\n");
+}
+
+void dump_matrix(unsigned char **s, int k, int m)
+{
+	int i, j;
+	for (i = 0; i < k; i++) {
+		for (j = 0; j < m; j++) {
+			printf(" %2x", s[i][j]);
+		}
+		printf("\n");
+	}
+	printf("\n");
+}
+
+void dump_u8xu8(unsigned char *s, int k, int m)
+{
+	int i, j;
+	for (i = 0; i < k; i++) {
+		for (j = 0; j < m; j++) {
+			printf(" %2x", 0xff & s[j + (i * m)]);
+		}
+		printf("\n");
+	}
+	printf("\n");
+}
+
+int main(int argc, char *argv[])
+{
+	int i, j, rtest, srcs;
+	void *buf;
+	u8 g1[TEST_SOURCES], g2[TEST_SOURCES], g3[TEST_SOURCES];
+	u8 g_tbls[3 * TEST_SOURCES * 32], *dest_ptrs[3], *buffs[TEST_SOURCES];
+	u8 *dest1, *dest2, *dest3, *dest_ref1, *dest_ref2, *dest_ref3;
+
+	int align, size;
+	unsigned char *efence_buffs[TEST_SOURCES];
+	unsigned int offset;
+	u8 *ubuffs[TEST_SOURCES];
+	u8 *udest_ptrs[3];
+	printf(xstr(FUNCTION_UNDER_TEST) "_test: %dx%d ", TEST_SOURCES, TEST_LEN);
+
+	// Allocate the arrays
+	for (i = 0; i < TEST_SOURCES; i++) {
+		if (posix_memalign(&buf, 64, TEST_LEN)) {
+			printf("alloc error: Fail");
+			return -1;
+		}
+		buffs[i] = buf;
+	}
+
+	if (posix_memalign(&buf, 64, TEST_LEN)) {
+		printf("alloc error: Fail");
+		return -1;
+	}
+	dest1 = buf;
+
+	if (posix_memalign(&buf, 64, TEST_LEN)) {
+		printf("alloc error: Fail");
+		return -1;
+	}
+	dest2 = buf;
+
+	if (posix_memalign(&buf, 64, TEST_LEN)) {
+		printf("alloc error: Fail");
+		return -1;
+	}
+	dest3 = buf;
+
+	if (posix_memalign(&buf, 64, TEST_LEN)) {
+		printf("alloc error: Fail");
+		return -1;
+	}
+	dest_ref1 = buf;
+
+	if (posix_memalign(&buf, 64, TEST_LEN)) {
+		printf("alloc error: Fail");;
+		return -1;
+	}
+	dest_ref2 = buf;
+
+	if (posix_memalign(&buf, 64, TEST_LEN)) {
+		printf("alloc error: Fail");
+		return -1;
+	}
+	dest_ref3 = buf;
+
+	dest_ptrs[0] = dest1;
+	dest_ptrs[1] = dest2;
+	dest_ptrs[2] = dest3;
+
+	// Test of all zeros
+	for (i = 0; i < TEST_SOURCES; i++)
+		memset(buffs[i], 0, TEST_LEN);
+
+	memset(dest1, 0, TEST_LEN);
+	memset(dest2, 0, TEST_LEN);
+	memset(dest3, 0, TEST_LEN);
+	memset(dest_ref1, 0, TEST_LEN);
+	memset(dest_ref2, 0, TEST_LEN);
+	memset(dest_ref3, 0, TEST_LEN);
+	memset(g1, 2, TEST_SOURCES);
+	memset(g2, 1, TEST_SOURCES);
+	memset(g3, 7, TEST_SOURCES);
+
+	for (i = 0; i < TEST_SOURCES; i++) {
+		gf_vect_mul_init(g1[i], &g_tbls[i * 32]);
+		gf_vect_mul_init(g2[i], &g_tbls[32 * TEST_SOURCES + i * 32]);
+		gf_vect_mul_init(g3[i], &g_tbls[64 * TEST_SOURCES + i * 32]);
+	}
+
+	gf_vect_dot_prod_base(TEST_LEN, TEST_SOURCES, &g_tbls[0], buffs, dest_ref1);
+	gf_vect_dot_prod_base(TEST_LEN, TEST_SOURCES, &g_tbls[32 * TEST_SOURCES], buffs,
+			      dest_ref2);
+	gf_vect_dot_prod_base(TEST_LEN, TEST_SOURCES, &g_tbls[64 * TEST_SOURCES], buffs,
+			      dest_ref3);
+
+	FUNCTION_UNDER_TEST(TEST_LEN, TEST_SOURCES, g_tbls, buffs, dest_ptrs);
+
+	if (0 != memcmp(dest_ref1, dest1, TEST_LEN)) {
+		printf("Fail zero" xstr(FUNCTION_UNDER_TEST) " test1\n");
+		dump_matrix(buffs, 5, TEST_SOURCES);
+		printf("dprod_base:");
+		dump(dest_ref1, 25);
+		printf("dprod_dut:");
+		dump(dest1, 25);
+		return -1;
+	}
+	if (0 != memcmp(dest_ref2, dest2, TEST_LEN)) {
+		printf("Fail zero " xstr(FUNCTION_UNDER_TEST) " test2\n");
+		dump_matrix(buffs, 5, TEST_SOURCES);
+		printf("dprod_base:");
+		dump(dest_ref2, 25);
+		printf("dprod_dut:");
+		dump(dest2, 25);
+		return -1;
+	}
+	if (0 != memcmp(dest_ref3, dest3, TEST_LEN)) {
+		printf("Fail zero " xstr(FUNCTION_UNDER_TEST) " test3\n");
+		dump_matrix(buffs, 5, TEST_SOURCES);
+		printf("dprod_base:");
+		dump(dest_ref3, 25);
+		printf("dprod_dut:");
+		dump(dest3, 25);
+		return -1;
+	}
+
+	putchar('.');
+
+	// Rand data test
+
+	for (rtest = 0; rtest < RANDOMS; rtest++) {
+		for (i = 0; i < TEST_SOURCES; i++)
+			for (j = 0; j < TEST_LEN; j++)
+				buffs[i][j] = rand();
+
+		for (i = 0; i < TEST_SOURCES; i++) {
+			g1[i] = rand();
+			g2[i] = rand();
+			g3[i] = rand();
+		}
+
+		for (i = 0; i < TEST_SOURCES; i++) {
+			gf_vect_mul_init(g1[i], &g_tbls[i * 32]);
+			gf_vect_mul_init(g2[i], &g_tbls[(32 * TEST_SOURCES) + (i * 32)]);
+			gf_vect_mul_init(g3[i], &g_tbls[(64 * TEST_SOURCES) + (i * 32)]);
+		}
+
+		gf_vect_dot_prod_base(TEST_LEN, TEST_SOURCES, &g_tbls[0], buffs, dest_ref1);
+		gf_vect_dot_prod_base(TEST_LEN, TEST_SOURCES, &g_tbls[32 * TEST_SOURCES],
+				      buffs, dest_ref2);
+		gf_vect_dot_prod_base(TEST_LEN, TEST_SOURCES, &g_tbls[64 * TEST_SOURCES],
+				      buffs, dest_ref3);
+
+		FUNCTION_UNDER_TEST(TEST_LEN, TEST_SOURCES, g_tbls, buffs, dest_ptrs);
+
+		if (0 != memcmp(dest_ref1, dest1, TEST_LEN)) {
+			printf("Fail rand " xstr(FUNCTION_UNDER_TEST) " test1 %d\n", rtest);
+			dump_matrix(buffs, 5, TEST_SOURCES);
+			printf("dprod_base:");
+			dump(dest_ref1, 25);
+			printf("dprod_dut:");
+			dump(dest1, 25);
+			return -1;
+		}
+		if (0 != memcmp(dest_ref2, dest2, TEST_LEN)) {
+			printf("Fail rand " xstr(FUNCTION_UNDER_TEST) " test2 %d\n", rtest);
+			dump_matrix(buffs, 5, TEST_SOURCES);
+			printf("dprod_base:");
+			dump(dest_ref2, 25);
+			printf("dprod_dut:");
+			dump(dest2, 25);
+			return -1;
+		}
+		if (0 != memcmp(dest_ref3, dest3, TEST_LEN)) {
+			printf("Fail rand " xstr(FUNCTION_UNDER_TEST) " test3 %d\n", rtest);
+			dump_matrix(buffs, 5, TEST_SOURCES);
+			printf("dprod_base:");
+			dump(dest_ref3, 25);
+			printf("dprod_dut:");
+			dump(dest3, 25);
+			return -1;
+		}
+
+		putchar('.');
+	}
+
+	// Rand data test with varied parameters
+	for (rtest = 0; rtest < RANDOMS; rtest++) {
+		for (srcs = TEST_SOURCES; srcs > 0; srcs--) {
+			for (i = 0; i < srcs; i++)
+				for (j = 0; j < TEST_LEN; j++)
+					buffs[i][j] = rand();
+
+			for (i = 0; i < srcs; i++) {
+				g1[i] = rand();
+				g2[i] = rand();
+				g3[i] = rand();
+			}
+
+			for (i = 0; i < srcs; i++) {
+				gf_vect_mul_init(g1[i], &g_tbls[i * 32]);
+				gf_vect_mul_init(g2[i], &g_tbls[(32 * srcs) + (i * 32)]);
+				gf_vect_mul_init(g3[i], &g_tbls[(64 * srcs) + (i * 32)]);
+			}
+
+			gf_vect_dot_prod_base(TEST_LEN, srcs, &g_tbls[0], buffs, dest_ref1);
+			gf_vect_dot_prod_base(TEST_LEN, srcs, &g_tbls[32 * srcs], buffs,
+					      dest_ref2);
+			gf_vect_dot_prod_base(TEST_LEN, srcs, &g_tbls[64 * srcs], buffs,
+					      dest_ref3);
+
+			FUNCTION_UNDER_TEST(TEST_LEN, srcs, g_tbls, buffs, dest_ptrs);
+
+			if (0 != memcmp(dest_ref1, dest1, TEST_LEN)) {
+				printf("Fail rand " xstr(FUNCTION_UNDER_TEST)
+				       " test1 srcs=%d\n", srcs);
+				dump_matrix(buffs, 5, TEST_SOURCES);
+				printf("dprod_base:");
+				dump(dest_ref1, 25);
+				printf("dprod_dut:");
+				dump(dest1, 25);
+				return -1;
+			}
+			if (0 != memcmp(dest_ref2, dest2, TEST_LEN)) {
+				printf("Fail rand " xstr(FUNCTION_UNDER_TEST)
+				       " test2 srcs=%d\n", srcs);
+				dump_matrix(buffs, 5, TEST_SOURCES);
+				printf("dprod_base:");
+				dump(dest_ref2, 25);
+				printf("dprod_dut:");
+				dump(dest2, 25);
+				return -1;
+			}
+			if (0 != memcmp(dest_ref3, dest3, TEST_LEN)) {
+				printf("Fail rand " xstr(FUNCTION_UNDER_TEST)
+				       " test3 srcs=%d\n", srcs);
+				dump_matrix(buffs, 5, TEST_SOURCES);
+				printf("dprod_base:");
+				dump(dest_ref3, 25);
+				printf("dprod_dut:");
+				dump(dest3, 25);
+				return -1;
+			}
+
+			putchar('.');
+		}
+	}
+
+	// Run tests at end of buffer for Electric Fence
+	align = (LEN_ALIGN_CHK_B != 0) ? 1 : 16;
+	for (size = TEST_MIN_SIZE; size <= TEST_SIZE; size += align) {
+		for (i = 0; i < TEST_SOURCES; i++)
+			for (j = 0; j < TEST_LEN; j++)
+				buffs[i][j] = rand();
+
+		for (i = 0; i < TEST_SOURCES; i++)	// Line up TEST_SIZE from end
+			efence_buffs[i] = buffs[i] + TEST_LEN - size;
+
+		for (i = 0; i < TEST_SOURCES; i++) {
+			g1[i] = rand();
+			g2[i] = rand();
+			g3[i] = rand();
+		}
+
+		for (i = 0; i < TEST_SOURCES; i++) {
+			gf_vect_mul_init(g1[i], &g_tbls[i * 32]);
+			gf_vect_mul_init(g2[i], &g_tbls[(32 * TEST_SOURCES) + (i * 32)]);
+			gf_vect_mul_init(g3[i], &g_tbls[(64 * TEST_SOURCES) + (i * 32)]);
+		}
+
+		gf_vect_dot_prod_base(size, TEST_SOURCES, &g_tbls[0], efence_buffs, dest_ref1);
+		gf_vect_dot_prod_base(size, TEST_SOURCES, &g_tbls[32 * TEST_SOURCES],
+				      efence_buffs, dest_ref2);
+		gf_vect_dot_prod_base(size, TEST_SOURCES, &g_tbls[64 * TEST_SOURCES],
+				      efence_buffs, dest_ref3);
+
+		FUNCTION_UNDER_TEST(size, TEST_SOURCES, g_tbls, efence_buffs, dest_ptrs);
+
+		if (0 != memcmp(dest_ref1, dest1, size)) {
+			printf("Fail rand " xstr(FUNCTION_UNDER_TEST) " test1 %d\n", rtest);
+			dump_matrix(efence_buffs, 5, TEST_SOURCES);
+			printf("dprod_base:");
+			dump(dest_ref1, align);
+			printf("dprod_dut:");
+			dump(dest1, align);
+			return -1;
+		}
+
+		if (0 != memcmp(dest_ref2, dest2, size)) {
+			printf("Fail rand " xstr(FUNCTION_UNDER_TEST) " test2 %d\n", rtest);
+			dump_matrix(efence_buffs, 5, TEST_SOURCES);
+			printf("dprod_base:");
+			dump(dest_ref2, align);
+			printf("dprod_dut:");
+			dump(dest2, align);
+			return -1;
+		}
+
+		if (0 != memcmp(dest_ref3, dest3, size)) {
+			printf("Fail rand " xstr(FUNCTION_UNDER_TEST) " test3 %d\n", rtest);
+			dump_matrix(efence_buffs, 5, TEST_SOURCES);
+			printf("dprod_base:");
+			dump(dest_ref3, align);
+			printf("dprod_dut:");
+			dump(dest3, align);
+			return -1;
+		}
+
+		putchar('.');
+	}
+
+	// Test rand ptr alignment if available
+
+	for (rtest = 0; rtest < RANDOMS; rtest++) {
+		size = (TEST_LEN - PTR_ALIGN_CHK_B) & ~(TEST_MIN_SIZE - 1);
+		srcs = rand() % TEST_SOURCES;
+		if (srcs == 0)
+			continue;
+
+		offset = (PTR_ALIGN_CHK_B != 0) ? 1 : PTR_ALIGN_CHK_B;
+		// Add random offsets
+		for (i = 0; i < srcs; i++)
+			ubuffs[i] = buffs[i] + (rand() & (PTR_ALIGN_CHK_B - offset));
+
+		udest_ptrs[0] = dest1 + (rand() & (PTR_ALIGN_CHK_B - offset));
+		udest_ptrs[1] = dest2 + (rand() & (PTR_ALIGN_CHK_B - offset));
+		udest_ptrs[2] = dest3 + (rand() & (PTR_ALIGN_CHK_B - offset));
+
+		memset(dest1, 0, TEST_LEN);	// zero pad to check write-over
+		memset(dest2, 0, TEST_LEN);
+		memset(dest3, 0, TEST_LEN);
+
+		for (i = 0; i < srcs; i++)
+			for (j = 0; j < size; j++)
+				ubuffs[i][j] = rand();
+
+		for (i = 0; i < srcs; i++) {
+			g1[i] = rand();
+			g2[i] = rand();
+			g3[i] = rand();
+		}
+
+		for (i = 0; i < srcs; i++) {
+			gf_vect_mul_init(g1[i], &g_tbls[i * 32]);
+			gf_vect_mul_init(g2[i], &g_tbls[(32 * srcs) + (i * 32)]);
+			gf_vect_mul_init(g3[i], &g_tbls[(64 * srcs) + (i * 32)]);
+		}
+
+		gf_vect_dot_prod_base(size, srcs, &g_tbls[0], ubuffs, dest_ref1);
+		gf_vect_dot_prod_base(size, srcs, &g_tbls[32 * srcs], ubuffs, dest_ref2);
+		gf_vect_dot_prod_base(size, srcs, &g_tbls[64 * srcs], ubuffs, dest_ref3);
+
+		FUNCTION_UNDER_TEST(size, srcs, g_tbls, ubuffs, udest_ptrs);
+
+		if (memcmp(dest_ref1, udest_ptrs[0], size)) {
+			printf("Fail rand " xstr(FUNCTION_UNDER_TEST) " test ualign srcs=%d\n",
+			       srcs);
+			dump_matrix(ubuffs, 5, TEST_SOURCES);
+			printf("dprod_base:");
+			dump(dest_ref1, 25);
+			printf("dprod_dut:");
+			dump(udest_ptrs[0], 25);
+			return -1;
+		}
+		if (memcmp(dest_ref2, udest_ptrs[1], size)) {
+			printf("Fail rand " xstr(FUNCTION_UNDER_TEST) " test ualign srcs=%d\n",
+			       srcs);
+			dump_matrix(ubuffs, 5, TEST_SOURCES);
+			printf("dprod_base:");
+			dump(dest_ref2, 25);
+			printf("dprod_dut:");
+			dump(udest_ptrs[1], 25);
+			return -1;
+		}
+		if (memcmp(dest_ref3, udest_ptrs[2], size)) {
+			printf("Fail rand " xstr(FUNCTION_UNDER_TEST) " test ualign srcs=%d\n",
+			       srcs);
+			dump_matrix(ubuffs, 5, TEST_SOURCES);
+			printf("dprod_base:");
+			dump(dest_ref3, 25);
+			printf("dprod_dut:");
+			dump(udest_ptrs[2], 25);
+			return -1;
+		}
+		// Confirm that padding around dests is unchanged
+		memset(dest_ref1, 0, PTR_ALIGN_CHK_B);	// Make reference zero buff
+		offset = udest_ptrs[0] - dest1;
+
+		if (memcmp(dest1, dest_ref1, offset)) {
+			printf("Fail rand ualign pad1 start\n");
+			return -1;
+		}
+		if (memcmp(dest1 + offset + size, dest_ref1, PTR_ALIGN_CHK_B - offset)) {
+			printf("Fail rand ualign pad1 end\n");
+			return -1;
+		}
+
+		offset = udest_ptrs[1] - dest2;
+		if (memcmp(dest2, dest_ref1, offset)) {
+			printf("Fail rand ualign pad2 start\n");
+			return -1;
+		}
+		if (memcmp(dest2 + offset + size, dest_ref1, PTR_ALIGN_CHK_B - offset)) {
+			printf("Fail rand ualign pad2 end\n");
+			return -1;
+		}
+
+		offset = udest_ptrs[2] - dest3;
+		if (memcmp(dest3, dest_ref1, offset)) {
+			printf("Fail rand ualign pad3 start\n");
+			return -1;
+		}
+		if (memcmp(dest3 + offset + size, dest_ref1, PTR_ALIGN_CHK_B - offset)) {
+			printf("Fail rand ualign pad3 end\n");;
+			return -1;
+		}
+
+		putchar('.');
+	}
+
+	// Test all size alignment
+	align = (LEN_ALIGN_CHK_B != 0) ? 1 : 16;
+
+	for (size = TEST_LEN; size >= TEST_MIN_SIZE; size -= align) {
+		srcs = TEST_SOURCES;
+
+		for (i = 0; i < srcs; i++)
+			for (j = 0; j < size; j++)
+				buffs[i][j] = rand();
+
+		for (i = 0; i < srcs; i++) {
+			g1[i] = rand();
+			g2[i] = rand();
+			g3[i] = rand();
+		}
+
+		for (i = 0; i < srcs; i++) {
+			gf_vect_mul_init(g1[i], &g_tbls[i * 32]);
+			gf_vect_mul_init(g2[i], &g_tbls[(32 * srcs) + (i * 32)]);
+			gf_vect_mul_init(g3[i], &g_tbls[(64 * srcs) + (i * 32)]);
+		}
+
+		gf_vect_dot_prod_base(size, srcs, &g_tbls[0], buffs, dest_ref1);
+		gf_vect_dot_prod_base(size, srcs, &g_tbls[32 * srcs], buffs, dest_ref2);
+		gf_vect_dot_prod_base(size, srcs, &g_tbls[64 * srcs], buffs, dest_ref3);
+
+		FUNCTION_UNDER_TEST(size, srcs, g_tbls, buffs, dest_ptrs);
+
+		if (memcmp(dest_ref1, dest_ptrs[0], size)) {
+			printf("Fail rand " xstr(FUNCTION_UNDER_TEST) " test ualign len=%d\n",
+			       size);
+			dump_matrix(buffs, 5, TEST_SOURCES);
+			printf("dprod_base:");
+			dump(dest_ref1, 25);
+			printf("dprod_dut:");
+			dump(dest_ptrs[0], 25);
+			return -1;
+		}
+		if (memcmp(dest_ref2, dest_ptrs[1], size)) {
+			printf("Fail rand " xstr(FUNCTION_UNDER_TEST) " test ualign len=%d\n",
+			       size);
+			dump_matrix(buffs, 5, TEST_SOURCES);
+			printf("dprod_base:");
+			dump(dest_ref2, 25);
+			printf("dprod_dut:");
+			dump(dest_ptrs[1], 25);
+			return -1;
+		}
+		if (memcmp(dest_ref3, dest_ptrs[2], size)) {
+			printf("Fail rand " xstr(FUNCTION_UNDER_TEST) " test ualign len=%d\n",
+			       size);
+			dump_matrix(buffs, 5, TEST_SOURCES);
+			printf("dprod_base:");
+			dump(dest_ref3, 25);
+			printf("dprod_dut:");
+			dump(dest_ptrs[2], 25);
+			return -1;
+		}
+	}
+
+	printf("Pass\n");
+	return 0;
+
+}

--- a/erasure_code/loongarch64/gf_3vect_mad_lasx.c
+++ b/erasure_code/loongarch64/gf_3vect_mad_lasx.c
@@ -1,0 +1,190 @@
+/**********************************************************************
+  Copyright(c) 2022 Loongson Tech All rights reserved.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions
+  are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in
+      the documentation and/or other materials provided with the
+      distribution.
+    * Neither the name of Intel Corporation nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+**********************************************************************/
+
+#include <lasxintrin.h>
+
+void gf_3vect_mad_lasx(int len, int vec, int vec_i, unsigned char *gftbls,
+		       unsigned char *src, unsigned char **dest)
+{
+	int i, l;
+	int skip1 = vec << 5;
+	int skip2 = skip1 << 1;
+
+	int block_count = len >> 5;
+	int remain = len - (block_count << 5);
+	int buf_offset = 0, col_offset = vec_i << 5;
+
+	__m256i block, high_idx, low_idx;
+	__m256i high_elem, low_elem;
+       	__m256i	high_val, low_val;
+	__m256i res;
+
+	unsigned long index, tmp, tmp1;
+	unsigned char *pos;
+	unsigned char sval;
+
+	for (i = 0; i < block_count; ++i) {
+		/* read one block from src to update three rows */
+
+		buf_offset = i << 5;
+		// fetch one block from one buf into a vector variable,
+		// the block size is 32 bytes
+		block = __lasx_xvldx(src, buf_offset);
+
+		// get low indexes
+		low_idx = __lasx_xvandi_b(block, 0x0F);
+
+		// get high indexes: shift right 4 bits and add 0x10,
+		// which can index {0x10, ..., 0x1F}
+		high_idx = __lasx_xvori_b(__lasx_xvsrli_b(block, 4), 0x10);
+
+		/* =================== for row 0 =================== */
+		// fetch one element from gftbls, which is 32 bytes
+		low_elem = __lasx_xvldx(gftbls, col_offset);
+		high_elem = low_elem;
+
+		// duplicate low part
+		low_elem = __lasx_xvpermi_d(low_elem, 0x44);
+
+		// duplicate high part
+		high_elem = __lasx_xvpermi_d(high_elem, 0xEE);
+
+		// pick by low_idx
+		low_val = __lasx_xvshuf_b(low_elem, low_elem, low_idx);
+
+		// pick by high_idx
+		high_val = __lasx_xvshuf_b(high_elem, high_elem, high_idx);
+
+		// load old data
+		res = __lasx_xvldx(dest[0], buf_offset);
+
+		// accumulation on GF(2^8)
+		res = __lasx_xvxor_v(res, __lasx_xvxor_v(low_val, high_val));
+
+		// store new data
+		__lasx_xvstx(res, dest[0], buf_offset);
+
+		/* =================== for row 1 =================== */
+		// fetch one element from gftbls, which is 32 bytes
+		low_elem = __lasx_xvldx(gftbls, col_offset + skip1);
+		high_elem = low_elem;
+
+		// duplicate low part
+		low_elem = __lasx_xvpermi_d(low_elem, 0x44);
+
+		// duplicate high part
+		high_elem = __lasx_xvpermi_d(high_elem, 0xEE);
+
+		// pick by low_idx
+		low_val = __lasx_xvshuf_b(low_elem, low_elem, low_idx);
+
+		// pick by high_idx
+		high_val = __lasx_xvshuf_b(high_elem, high_elem, high_idx);
+
+		// load old data
+		res = __lasx_xvldx(dest[1], buf_offset);
+
+		// accumulation on GF(2^8)
+		res = __lasx_xvxor_v(res, __lasx_xvxor_v(low_val, high_val));
+
+		// store new data
+		__lasx_xvstx(res, dest[1], buf_offset);
+
+		/* =================== for row 2 =================== */
+		// fetch one element from gftbls, which is 32 bytes
+		low_elem = __lasx_xvldx(gftbls, col_offset + skip2);
+		high_elem = low_elem;
+
+		// duplicate low part
+		low_elem = __lasx_xvpermi_d(low_elem, 0x44);
+
+		// duplicate high part
+		high_elem = __lasx_xvpermi_d(high_elem, 0xEE);
+
+		// pick by low_idx
+		low_val = __lasx_xvshuf_b(low_elem, low_elem, low_idx);
+
+		// pick by high_idx
+		high_val = __lasx_xvshuf_b(high_elem, high_elem, high_idx);
+
+		// load old data
+		res = __lasx_xvldx(dest[2], buf_offset);
+
+		// accumulation on GF(2^8)
+		res = __lasx_xvxor_v(res, __lasx_xvxor_v(low_val, high_val));
+
+		// store new data
+		__lasx_xvstx(res, dest[2], buf_offset);
+	}
+
+	if (remain == 0)
+		return;
+
+	// handle remain bytes
+	i = block_count << 5;
+	while (remain >= 8) {
+		tmp1 = *(unsigned long *)&src[i];
+		for (l = 0; l < 3; ++l) {
+			index = tmp1;
+			pos = &gftbls[col_offset + l * skip1];
+
+			tmp = pos[index & 0xF] ^ pos[16 + ((index >> 4) & 0xF)];
+			index = index >> 8;
+			tmp |= (unsigned long)(pos[index & 0xF] ^ pos[16 + ((index >> 4) & 0xF)]) << 8;
+			index = index >> 8;
+			tmp |= (unsigned long)(pos[index & 0xF] ^ pos[16 + ((index >> 4) & 0xF)]) << 16;
+			index = index >> 8;
+			tmp |= (unsigned long)(pos[index & 0xF] ^ pos[16 + ((index >> 4) & 0xF)]) << 24;
+			index = index >> 8;
+			tmp |= (unsigned long)(pos[index & 0xF] ^ pos[16 + ((index >> 4) & 0xF)]) << 32;
+			index = index >> 8;
+			tmp |= (unsigned long)(pos[index & 0xF] ^ pos[16 + ((index >> 4) & 0xF)]) << 40;
+			index = index >> 8;
+			tmp |= (unsigned long)(pos[index & 0xF] ^ pos[16 + ((index >> 4) & 0xF)]) << 48;
+			index = index >> 8;
+			tmp |= (unsigned long)(pos[index & 0xF] ^ pos[16 + ((index >> 4) & 0xF)]) << 56;
+
+			*(unsigned long *)&dest[l][i] ^= tmp;
+		}
+		i += sizeof(unsigned long);
+		remain -= sizeof(unsigned long);
+	}
+
+	if (remain == 0)
+		return;
+
+	buf_offset = i;
+	for (l = 0; l < 3; l++) {
+		for (i = buf_offset; i < len; i++) {
+			sval = src[i];
+			pos = &gftbls[col_offset + l * skip1];
+			dest[l][i] ^= pos[sval & 0xF] ^ pos[16 + (sval >> 4)];
+		}
+	}
+}

--- a/erasure_code/loongarch64/gf_3vect_mad_lasx_test.c
+++ b/erasure_code/loongarch64/gf_3vect_mad_lasx_test.c
@@ -1,0 +1,519 @@
+/**********************************************************************
+  Copyright(c) 2011-2015 Intel Corporation All rights reserved.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions
+  are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in
+      the documentation and/or other materials provided with the
+      distribution.
+    * Neither the name of Intel Corporation nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+**********************************************************************/
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>		// for memset, memcmp
+#include "erasure_code.h"
+#include "types.h"
+
+#ifndef ALIGN_SIZE
+# define ALIGN_SIZE 32
+#endif
+
+#ifndef FUNCTION_UNDER_TEST
+//By default, test multi-binary version
+# define FUNCTION_UNDER_TEST gf_3vect_mad_lasx
+# define REF_FUNCTION gf_3vect_dot_prod_lasx
+# define VECT 3
+#endif
+
+#ifndef TEST_MIN_SIZE
+# define TEST_MIN_SIZE 64
+#endif
+
+#define str(s) #s
+#define xstr(s) str(s)
+
+#define TEST_LEN (8192+31)
+#define TEST_SIZE (TEST_LEN/2)
+#define TEST_MEM  TEST_SIZE
+#define TEST_LOOPS 20000
+#define TEST_TYPE_STR ""
+
+#ifndef TEST_SOURCES
+# define TEST_SOURCES  16
+#endif
+#ifndef RANDOMS
+# define RANDOMS 20
+#endif
+
+#ifdef EC_ALIGNED_ADDR
+// Define power of 2 range to check ptr, len alignment
+# define PTR_ALIGN_CHK_B 0
+# define LEN_ALIGN_CHK_B 0	// 0 for aligned only
+#else
+// Define power of 2 range to check ptr, len alignment
+# define PTR_ALIGN_CHK_B ALIGN_SIZE
+# define LEN_ALIGN_CHK_B ALIGN_SIZE	// 0 for aligned only
+#endif
+
+#define str(s) #s
+#define xstr(s) str(s)
+
+typedef unsigned char u8;
+
+#if (VECT == 1)
+# define LAST_ARG *dest
+#else
+# define LAST_ARG **dest
+#endif
+
+extern void FUNCTION_UNDER_TEST(int len, int vec, int vec_i, unsigned char *gftbls,
+				unsigned char *src, unsigned char LAST_ARG);
+extern void REF_FUNCTION(int len, int vlen, unsigned char *gftbls, unsigned char **src,
+			 unsigned char LAST_ARG);
+
+void dump(unsigned char *buf, int len)
+{
+	int i;
+	for (i = 0; i < len;) {
+		printf(" %2x", 0xff & buf[i++]);
+		if (i % 32 == 0)
+			printf("\n");
+	}
+	printf("\n");
+}
+
+void dump_matrix(unsigned char **s, int k, int m)
+{
+	int i, j;
+	for (i = 0; i < k; i++) {
+		for (j = 0; j < m; j++) {
+			printf(" %2x", s[i][j]);
+		}
+		printf("\n");
+	}
+	printf("\n");
+}
+
+void dump_u8xu8(unsigned char *s, int k, int m)
+{
+	int i, j;
+	for (i = 0; i < k; i++) {
+		for (j = 0; j < m; j++) {
+			printf(" %2x", 0xff & s[j + (i * m)]);
+		}
+		printf("\n");
+	}
+	printf("\n");
+}
+
+int main(int argc, char *argv[])
+{
+	int i, j, rtest, srcs;
+	void *buf;
+	u8 gf[6][TEST_SOURCES];
+	u8 *g_tbls;
+	u8 *dest_ref[VECT];
+	u8 *dest_ptrs[VECT], *buffs[TEST_SOURCES];
+	int vector = VECT;
+
+	int align, size;
+	unsigned char *efence_buffs[TEST_SOURCES];
+	unsigned int offset;
+	u8 *ubuffs[TEST_SOURCES];
+	u8 *udest_ptrs[VECT];
+	printf("test" xstr(FUNCTION_UNDER_TEST) ": %dx%d ", TEST_SOURCES, TEST_LEN);
+
+	// Allocate the arrays
+	for (i = 0; i < TEST_SOURCES; i++) {
+		if (posix_memalign(&buf, 64, TEST_LEN)) {
+			printf("alloc error: Fail");
+			return -1;
+		}
+		buffs[i] = buf;
+	}
+
+	if (posix_memalign(&buf, 16, 2 * (vector * TEST_SOURCES * 32))) {
+		printf("alloc error: Fail");
+		return -1;
+	}
+	g_tbls = buf;
+
+	for (i = 0; i < vector; i++) {
+		if (posix_memalign(&buf, 64, TEST_LEN)) {
+			printf("alloc error: Fail");
+			return -1;
+		}
+		dest_ptrs[i] = buf;
+		memset(dest_ptrs[i], 0, TEST_LEN);
+	}
+
+	for (i = 0; i < vector; i++) {
+		if (posix_memalign(&buf, 64, TEST_LEN)) {
+			printf("alloc error: Fail");
+			return -1;
+		}
+		dest_ref[i] = buf;
+		memset(dest_ref[i], 0, TEST_LEN);
+	}
+
+	// Test of all zeros
+	for (i = 0; i < TEST_SOURCES; i++)
+		memset(buffs[i], 0, TEST_LEN);
+
+	switch (vector) {
+	case 6:
+		memset(gf[5], 0xe6, TEST_SOURCES);
+	case 5:
+		memset(gf[4], 4, TEST_SOURCES);
+	case 4:
+		memset(gf[3], 9, TEST_SOURCES);
+	case 3:
+		memset(gf[2], 7, TEST_SOURCES);
+	case 2:
+		memset(gf[1], 1, TEST_SOURCES);
+	case 1:
+		memset(gf[0], 2, TEST_SOURCES);
+		break;
+	default:
+		return -1;
+	}
+
+	for (i = 0; i < TEST_SOURCES; i++)
+		for (j = 0; j < TEST_LEN; j++)
+			buffs[i][j] = rand();
+
+	for (i = 0; i < vector; i++)
+		for (j = 0; j < TEST_SOURCES; j++) {
+			gf[i][j] = rand();
+			gf_vect_mul_init(gf[i][j], &g_tbls[i * (32 * TEST_SOURCES) + j * 32]);
+		}
+
+	for (i = 0; i < vector; i++)
+		gf_vect_dot_prod_base(TEST_LEN, TEST_SOURCES, &g_tbls[i * 32 * TEST_SOURCES],
+				      buffs, dest_ref[i]);
+
+	for (i = 0; i < vector; i++)
+		memset(dest_ptrs[i], 0, TEST_LEN);
+	for (i = 0; i < TEST_SOURCES; i++) {
+#if (VECT == 1)
+		FUNCTION_UNDER_TEST(TEST_LEN, TEST_SOURCES, i, g_tbls, buffs[i], *dest_ptrs);
+#else
+		FUNCTION_UNDER_TEST(TEST_LEN, TEST_SOURCES, i, g_tbls, buffs[i], dest_ptrs);
+#endif
+	}
+	for (i = 0; i < vector; i++) {
+		if (0 != memcmp(dest_ref[i], dest_ptrs[i], TEST_LEN)) {
+			printf("Fail zero " xstr(FUNCTION_UNDER_TEST) " test%d\n", i);
+			dump_matrix(buffs, vector, TEST_SOURCES);
+			printf("dprod_base:");
+			dump(dest_ref[i], 25);
+			printf("dprod_dut:");
+			dump(dest_ptrs[i], 25);
+			return -1;
+		}
+	}
+
+#if (VECT == 1)
+	REF_FUNCTION(TEST_LEN, TEST_SOURCES, g_tbls, buffs, *dest_ref);
+#else
+	REF_FUNCTION(TEST_LEN, TEST_SOURCES, g_tbls, buffs, dest_ref);
+#endif
+	for (i = 0; i < vector; i++) {
+		if (0 != memcmp(dest_ref[i], dest_ptrs[i], TEST_LEN)) {
+			printf("Fail zero " xstr(FUNCTION_UNDER_TEST) " test%d\n", i);
+			dump_matrix(buffs, vector, TEST_SOURCES);
+			printf("dprod_base:");
+			dump(dest_ref[i], 25);
+			printf("dprod_dut:");
+			dump(dest_ptrs[i], 25);
+			return -1;
+		}
+	}
+
+	putchar('.');
+
+	// Rand data test
+
+	for (rtest = 0; rtest < RANDOMS; rtest++) {
+		for (i = 0; i < TEST_SOURCES; i++)
+			for (j = 0; j < TEST_LEN; j++)
+				buffs[i][j] = rand();
+
+		for (i = 0; i < vector; i++)
+			for (j = 0; j < TEST_SOURCES; j++) {
+				gf[i][j] = rand();
+				gf_vect_mul_init(gf[i][j],
+						 &g_tbls[i * (32 * TEST_SOURCES) + j * 32]);
+			}
+
+		for (i = 0; i < vector; i++)
+			gf_vect_dot_prod_base(TEST_LEN, TEST_SOURCES,
+					      &g_tbls[i * 32 * TEST_SOURCES], buffs,
+					      dest_ref[i]);
+
+		for (i = 0; i < vector; i++)
+			memset(dest_ptrs[i], 0, TEST_LEN);
+		for (i = 0; i < TEST_SOURCES; i++) {
+#if (VECT == 1)
+			FUNCTION_UNDER_TEST(TEST_LEN, TEST_SOURCES, i, g_tbls, buffs[i],
+					    *dest_ptrs);
+#else
+			FUNCTION_UNDER_TEST(TEST_LEN, TEST_SOURCES, i, g_tbls, buffs[i],
+					    dest_ptrs);
+#endif
+		}
+		for (i = 0; i < vector; i++) {
+			if (0 != memcmp(dest_ref[i], dest_ptrs[i], TEST_LEN)) {
+				printf("Fail rand " xstr(FUNCTION_UNDER_TEST) " test%d %d\n",
+				       i, rtest);
+				dump_matrix(buffs, vector, TEST_SOURCES);
+				printf("dprod_base:");
+				dump(dest_ref[i], 25);
+				printf("dprod_dut:");
+				dump(dest_ptrs[i], 25);
+				return -1;
+			}
+		}
+
+		putchar('.');
+	}
+
+	// Rand data test with varied parameters
+	for (rtest = 0; rtest < RANDOMS; rtest++) {
+		for (srcs = TEST_SOURCES; srcs > 0; srcs--) {
+			for (i = 0; i < srcs; i++)
+				for (j = 0; j < TEST_LEN; j++)
+					buffs[i][j] = rand();
+
+			for (i = 0; i < vector; i++)
+				for (j = 0; j < srcs; j++) {
+					gf[i][j] = rand();
+					gf_vect_mul_init(gf[i][j],
+							 &g_tbls[i * (32 * srcs) + j * 32]);
+				}
+
+			for (i = 0; i < vector; i++)
+				gf_vect_dot_prod_base(TEST_LEN, srcs, &g_tbls[i * 32 * srcs],
+						      buffs, dest_ref[i]);
+
+			for (i = 0; i < vector; i++)
+				memset(dest_ptrs[i], 0, TEST_LEN);
+			for (i = 0; i < srcs; i++) {
+#if (VECT == 1)
+				FUNCTION_UNDER_TEST(TEST_LEN, srcs, i, g_tbls, buffs[i],
+						    *dest_ptrs);
+#else
+				FUNCTION_UNDER_TEST(TEST_LEN, srcs, i, g_tbls, buffs[i],
+						    dest_ptrs);
+#endif
+
+			}
+			for (i = 0; i < vector; i++) {
+				if (0 != memcmp(dest_ref[i], dest_ptrs[i], TEST_LEN)) {
+					printf("Fail rand " xstr(FUNCTION_UNDER_TEST)
+					       " test%d srcs=%d\n", i, srcs);
+					dump_matrix(buffs, vector, TEST_SOURCES);
+					printf("dprod_base:");
+					dump(dest_ref[i], 25);
+					printf("dprod_dut:");
+					dump(dest_ptrs[i], 25);
+					return -1;
+				}
+			}
+
+			putchar('.');
+		}
+	}
+
+	// Run tests at end of buffer for Electric Fence
+	align = (LEN_ALIGN_CHK_B != 0) ? 1 : ALIGN_SIZE;
+	for (size = TEST_MIN_SIZE; size <= TEST_SIZE; size += align) {
+		for (i = 0; i < TEST_SOURCES; i++)
+			for (j = 0; j < TEST_LEN; j++)
+				buffs[i][j] = rand();
+
+		for (i = 0; i < TEST_SOURCES; i++)	// Line up TEST_SIZE from end
+			efence_buffs[i] = buffs[i] + TEST_LEN - size;
+
+		for (i = 0; i < vector; i++)
+			for (j = 0; j < TEST_SOURCES; j++) {
+				gf[i][j] = rand();
+				gf_vect_mul_init(gf[i][j],
+						 &g_tbls[i * (32 * TEST_SOURCES) + j * 32]);
+			}
+
+		for (i = 0; i < vector; i++)
+			gf_vect_dot_prod_base(size, TEST_SOURCES,
+					      &g_tbls[i * 32 * TEST_SOURCES], efence_buffs,
+					      dest_ref[i]);
+
+		for (i = 0; i < vector; i++)
+			memset(dest_ptrs[i], 0, size);
+		for (i = 0; i < TEST_SOURCES; i++) {
+#if (VECT == 1)
+			FUNCTION_UNDER_TEST(size, TEST_SOURCES, i, g_tbls, efence_buffs[i],
+					    *dest_ptrs);
+#else
+			FUNCTION_UNDER_TEST(size, TEST_SOURCES, i, g_tbls, efence_buffs[i],
+					    dest_ptrs);
+#endif
+		}
+		for (i = 0; i < vector; i++) {
+			if (0 != memcmp(dest_ref[i], dest_ptrs[i], size)) {
+				printf("Fail rand " xstr(FUNCTION_UNDER_TEST)
+				       " test%d size=%d\n", i, size);
+				dump_matrix(buffs, vector, TEST_SOURCES);
+				printf("dprod_base:");
+				dump(dest_ref[i], TEST_MIN_SIZE + align);
+				printf("dprod_dut:");
+				dump(dest_ptrs[i], TEST_MIN_SIZE + align);
+				return -1;
+			}
+		}
+
+		putchar('.');
+	}
+
+	// Test rand ptr alignment if available
+
+	for (rtest = 0; rtest < RANDOMS; rtest++) {
+		size = (TEST_LEN - PTR_ALIGN_CHK_B) & ~(TEST_MIN_SIZE - 1);
+		srcs = rand() % TEST_SOURCES;
+		if (srcs == 0)
+			continue;
+
+		offset = (PTR_ALIGN_CHK_B != 0) ? 1 : PTR_ALIGN_CHK_B;
+		// Add random offsets
+		for (i = 0; i < srcs; i++)
+			ubuffs[i] = buffs[i] + (rand() & (PTR_ALIGN_CHK_B - offset));
+
+		for (i = 0; i < vector; i++) {
+			udest_ptrs[i] = dest_ptrs[i] + (rand() & (PTR_ALIGN_CHK_B - offset));
+			memset(dest_ptrs[i], 0, TEST_LEN);	// zero pad to check write-over
+		}
+
+		for (i = 0; i < srcs; i++)
+			for (j = 0; j < size; j++)
+				ubuffs[i][j] = rand();
+
+		for (i = 0; i < vector; i++)
+			for (j = 0; j < srcs; j++) {
+				gf[i][j] = rand();
+				gf_vect_mul_init(gf[i][j], &g_tbls[i * (32 * srcs) + j * 32]);
+			}
+
+		for (i = 0; i < vector; i++)
+			gf_vect_dot_prod_base(size, srcs, &g_tbls[i * 32 * srcs], ubuffs,
+					      dest_ref[i]);
+
+		for (i = 0; i < srcs; i++) {
+#if (VECT == 1)
+			FUNCTION_UNDER_TEST(size, srcs, i, g_tbls, ubuffs[i], *udest_ptrs);
+#else
+			FUNCTION_UNDER_TEST(size, srcs, i, g_tbls, ubuffs[i], udest_ptrs);
+#endif
+		}
+		for (i = 0; i < vector; i++) {
+			if (0 != memcmp(dest_ref[i], udest_ptrs[i], size)) {
+				printf("Fail rand " xstr(FUNCTION_UNDER_TEST)
+				       " test%d ualign srcs=%d\n", i, srcs);
+				dump_matrix(buffs, vector, TEST_SOURCES);
+				printf("dprod_base:");
+				dump(dest_ref[i], 25);
+				printf("dprod_dut:");
+				dump(udest_ptrs[i], 25);
+				return -1;
+			}
+		}
+
+		// Confirm that padding around dests is unchanged
+		memset(dest_ref[0], 0, PTR_ALIGN_CHK_B);	// Make reference zero buff
+
+		for (i = 0; i < vector; i++) {
+			offset = udest_ptrs[i] - dest_ptrs[i];
+			if (memcmp(dest_ptrs[i], dest_ref[0], offset)) {
+				printf("Fail rand ualign pad1 start\n");
+				return -1;
+			}
+			if (memcmp
+			    (dest_ptrs[i] + offset + size, dest_ref[0],
+			     PTR_ALIGN_CHK_B - offset)) {
+				printf("Fail rand ualign pad1 end\n");
+				return -1;
+			}
+		}
+
+		putchar('.');
+	}
+
+	// Test all size alignment
+	align = (LEN_ALIGN_CHK_B != 0) ? 1 : ALIGN_SIZE;
+
+	for (size = TEST_LEN; size >= TEST_MIN_SIZE; size -= align) {
+		for (i = 0; i < TEST_SOURCES; i++)
+			for (j = 0; j < size; j++)
+				buffs[i][j] = rand();
+
+		for (i = 0; i < vector; i++) {
+			for (j = 0; j < TEST_SOURCES; j++) {
+				gf[i][j] = rand();
+				gf_vect_mul_init(gf[i][j],
+						 &g_tbls[i * (32 * TEST_SOURCES) + j * 32]);
+			}
+			memset(dest_ptrs[i], 0, TEST_LEN);	// zero pad to check write-over
+		}
+
+		for (i = 0; i < vector; i++)
+			gf_vect_dot_prod_base(size, TEST_SOURCES,
+					      &g_tbls[i * 32 * TEST_SOURCES], buffs,
+					      dest_ref[i]);
+
+		for (i = 0; i < TEST_SOURCES; i++) {
+#if (VECT == 1)
+			FUNCTION_UNDER_TEST(size, TEST_SOURCES, i, g_tbls, buffs[i],
+					    *dest_ptrs);
+#else
+			FUNCTION_UNDER_TEST(size, TEST_SOURCES, i, g_tbls, buffs[i],
+					    dest_ptrs);
+#endif
+		}
+		for (i = 0; i < vector; i++) {
+			if (0 != memcmp(dest_ref[i], dest_ptrs[i], size)) {
+				printf("Fail rand " xstr(FUNCTION_UNDER_TEST)
+				       " test%d ualign len=%d\n", i, size);
+				dump_matrix(buffs, vector, TEST_SOURCES);
+				printf("dprod_base:");
+				dump(dest_ref[i], 25);
+				printf("dprod_dut:");
+				dump(dest_ptrs[i], 25);
+				return -1;
+			}
+		}
+
+		putchar('.');
+
+	}
+
+	printf("Pass\n");
+	return 0;
+
+}

--- a/erasure_code/loongarch64/gf_4vect_dot_prod_lasx.c
+++ b/erasure_code/loongarch64/gf_4vect_dot_prod_lasx.c
@@ -1,0 +1,214 @@
+/**********************************************************************
+  Copyright(c) 2022 Loongson Tech All rights reserved.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions
+  are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in
+      the documentation and/or other materials provided with the
+      distribution.
+    * Neither the name of Intel Corporation nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+**********************************************************************/
+
+#include <lasxintrin.h>
+
+void gf_4vect_dot_prod_lasx(int len, int vlen, unsigned char *gftbls,
+			    unsigned char **src, unsigned char **dest)
+{
+	int i, j, l;
+	int skip1 = vlen << 5;
+	int skip2 = skip1 << 1;
+	int skip3 = skip1 + skip2;
+
+	int block_count = len >> 5;
+	int remain = len - (block_count << 5);
+	int buf_offset = 0, col_offset = 0;
+
+	__m256i block, high_idx, low_idx;
+	__m256i high_elem, low_elem;
+       	__m256i	high_val, low_val;
+	__m256i res1, res2, res3, res4;
+
+	unsigned long sul, index, tmp;
+	unsigned char *pos;
+	unsigned char suc, sval;
+
+	for (i = 0; i < block_count; ++i) {
+		res1 = __lasx_xvldi(0);
+		res2 = __lasx_xvldi(0);
+		res3 = __lasx_xvldi(0);
+		res4 = __lasx_xvldi(0);
+
+		buf_offset = i << 5;
+		for (j = 0; j < vlen; ++j) {
+			/* read one block from one buf to update four rows */
+
+			col_offset = j << 5;
+
+			// fetch one block from one buf into a vector variable,
+			// the block size is 32 bytes
+			block = __lasx_xvldx(src[j], buf_offset);
+
+			// get low indexes
+			low_idx = __lasx_xvandi_b(block, 0x0F);
+
+			// get high indexes: shift right 4 bits and add 0x10,
+			// which can index {0x10, ..., 0x1F}
+			high_idx = __lasx_xvori_b(__lasx_xvsrli_b(block, 4), 0x10);
+
+			/* =================== for row 0 =================== */
+			// fetch one element from gftbls, which is 32 bytes
+			low_elem = __lasx_xvldx(gftbls, col_offset);
+			high_elem = low_elem;
+
+			// duplicate low part
+			low_elem = __lasx_xvpermi_d(low_elem, 0x44);
+
+			// duplicate high part
+			high_elem = __lasx_xvpermi_d(high_elem, 0xEE);
+
+			// pick by low_idx
+			low_val = __lasx_xvshuf_b(low_elem, low_elem, low_idx);
+
+			// pick by high_idx
+			high_val = __lasx_xvshuf_b(high_elem, high_elem, high_idx);
+
+			// accumulation on GF(2^8)
+			res1 = __lasx_xvxor_v(res1, __lasx_xvxor_v(low_val, high_val));
+
+			/* =================== for row 1 =================== */
+			// fetch one element from gftbls, which is 32 bytes
+			low_elem = __lasx_xvldx(gftbls, col_offset + skip1);
+			high_elem = low_elem;
+
+			// duplicate low part
+			low_elem = __lasx_xvpermi_d(low_elem, 0x44);
+
+			// duplicate high part
+			high_elem = __lasx_xvpermi_d(high_elem, 0xEE);
+
+			// pick by low_idx
+			low_val = __lasx_xvshuf_b(low_elem, low_elem, low_idx);
+
+			// pick by high_idx
+			high_val = __lasx_xvshuf_b(high_elem, high_elem, high_idx);
+
+			// accumulation on GF(2^8)
+			res2 = __lasx_xvxor_v(res2, __lasx_xvxor_v(low_val, high_val));
+
+			/* =================== for row 2 =================== */
+			// fetch one element from gftbls, which is 32 bytes
+			low_elem = __lasx_xvldx(gftbls, col_offset + skip2);
+			high_elem = low_elem;
+
+			// duplicate low part
+			low_elem = __lasx_xvpermi_d(low_elem, 0x44);
+
+			// duplicate high part
+			high_elem = __lasx_xvpermi_d(high_elem, 0xEE);
+
+			// pick by low_idx
+			low_val = __lasx_xvshuf_b(low_elem, low_elem, low_idx);
+
+			// pick by high_idx
+			high_val = __lasx_xvshuf_b(high_elem, high_elem, high_idx);
+
+			// accumulation on GF(2^8)
+			res3 = __lasx_xvxor_v(res3, __lasx_xvxor_v(low_val, high_val));
+
+			/* =================== for row 3 =================== */
+			// fetch one element from gftbls, which is 32 bytes
+			low_elem = __lasx_xvldx(gftbls, col_offset + skip3);
+			high_elem = low_elem;
+
+			// duplicate low part
+			low_elem = __lasx_xvpermi_d(low_elem, 0x44);
+
+			// duplicate high part
+			high_elem = __lasx_xvpermi_d(high_elem, 0xEE);
+
+			// pick by low_idx
+			low_val = __lasx_xvshuf_b(low_elem, low_elem, low_idx);
+
+			// pick by high_idx
+			high_val = __lasx_xvshuf_b(high_elem, high_elem, high_idx);
+
+			// accumulation on GF(2^8)
+			res4 = __lasx_xvxor_v(res4, __lasx_xvxor_v(low_val, high_val));
+		}
+
+		__lasx_xvstx(res1, dest[0], buf_offset);
+		__lasx_xvstx(res2, dest[1], buf_offset);
+		__lasx_xvstx(res3, dest[2], buf_offset);
+		__lasx_xvstx(res4, dest[3], buf_offset);
+	}
+
+	if (remain == 0)
+		return;
+
+	// handle remain bytes
+	i = block_count << 5;
+	while (remain >= 8) {
+		for (l = 0; l < 4; ++l) {
+			sul = 0;
+			for (j = 0; j < vlen; ++j) {
+				index = *(unsigned long *)&src[j][i];
+				pos = &gftbls[(j << 5) + l * skip1];
+
+				tmp = pos[index & 0xF] ^ pos[16 + ((index >> 4) & 0xF)];
+				index = index >> 8;
+				tmp |= (unsigned long)(pos[index & 0xF] ^ pos[16 + ((index >> 4) & 0xF)]) << 8;
+				index = index >> 8;
+				tmp |= (unsigned long)(pos[index & 0xF] ^ pos[16 + ((index >> 4) & 0xF)]) << 16;
+				index = index >> 8;
+				tmp |= (unsigned long)(pos[index & 0xF] ^ pos[16 + ((index >> 4) & 0xF)]) << 24;
+				index = index >> 8;
+				tmp |= (unsigned long)(pos[index & 0xF] ^ pos[16 + ((index >> 4) & 0xF)]) << 32;
+				index = index >> 8;
+				tmp |= (unsigned long)(pos[index & 0xF] ^ pos[16 + ((index >> 4) & 0xF)]) << 40;
+				index = index >> 8;
+				tmp |= (unsigned long)(pos[index & 0xF] ^ pos[16 + ((index >> 4) & 0xF)]) << 48;
+				index = index >> 8;
+				tmp |= (unsigned long)(pos[index & 0xF] ^ pos[16 + ((index >> 4) & 0xF)]) << 56;
+
+				sul ^= tmp;
+			}
+			*(unsigned long *)&dest[l][i] = sul;
+		}
+		i += sizeof(unsigned long);
+		remain -= sizeof(unsigned long);
+	}
+
+	if (remain == 0)
+		return;
+
+	buf_offset = i;
+	for (l = 0; l < 4; l++) {
+		for (i = buf_offset; i < len; i++) {
+			suc = 0;
+			for (j = 0; j < vlen; j++) {
+				sval = src[j][i];
+				pos = &gftbls[(j << 5) + l * skip1];
+				suc ^= pos[sval & 0xF] ^ pos[16 + (sval >> 4)];
+			}
+			dest[l][i] = suc;
+		}
+	}
+}

--- a/erasure_code/loongarch64/gf_4vect_dot_prod_lasx_test.c
+++ b/erasure_code/loongarch64/gf_4vect_dot_prod_lasx_test.c
@@ -1,0 +1,696 @@
+/**********************************************************************
+  Copyright(c) 2011-2015 Intel Corporation All rights reserved.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions
+  are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in
+      the documentation and/or other materials provided with the
+      distribution.
+    * Neither the name of Intel Corporation nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+**********************************************************************/
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>		// for memset, memcmp
+#include "erasure_code.h"
+#include "ec_loongarch64.h"
+#include "types.h"
+
+#ifndef FUNCTION_UNDER_TEST
+# define FUNCTION_UNDER_TEST gf_4vect_dot_prod_lasx
+#endif
+#ifndef TEST_MIN_SIZE
+# define TEST_MIN_SIZE  16
+#endif
+
+#define str(s) #s
+#define xstr(s) str(s)
+
+#define TEST_LEN (8192+31)
+#define TEST_SIZE (TEST_LEN/2)
+#define TEST_MEM  TEST_SIZE
+#define TEST_LOOPS 10000
+#define TEST_TYPE_STR ""
+
+#ifndef TEST_SOURCES
+# define TEST_SOURCES  16
+#endif
+#ifndef RANDOMS
+# define RANDOMS 20
+#endif
+
+#ifdef EC_ALIGNED_ADDR
+// Define power of 2 range to check ptr, len alignment
+# define PTR_ALIGN_CHK_B 0
+# define LEN_ALIGN_CHK_B 0	// 0 for aligned only
+#else
+// Define power of 2 range to check ptr, len alignment
+# define PTR_ALIGN_CHK_B 32
+# define LEN_ALIGN_CHK_B 32	// 0 for aligned only
+#endif
+
+typedef unsigned char u8;
+
+extern void FUNCTION_UNDER_TEST(int len, int vlen, unsigned char *gftbls,
+				unsigned char **src, unsigned char **dest);
+
+void dump(unsigned char *buf, int len)
+{
+	int i;
+	for (i = 0; i < len;) {
+		printf(" %2x", 0xff & buf[i++]);
+		if (i % 32 == 0)
+			printf("\n");
+	}
+	printf("\n");
+}
+
+void dump_matrix(unsigned char **s, int k, int m)
+{
+	int i, j;
+	for (i = 0; i < k; i++) {
+		for (j = 0; j < m; j++) {
+			printf(" %2x", s[i][j]);
+		}
+		printf("\n");
+	}
+	printf("\n");
+}
+
+void dump_u8xu8(unsigned char *s, int k, int m)
+{
+	int i, j;
+	for (i = 0; i < k; i++) {
+		for (j = 0; j < m; j++) {
+			printf(" %2x", 0xff & s[j + (i * m)]);
+		}
+		printf("\n");
+	}
+	printf("\n");
+}
+
+int main(int argc, char *argv[])
+{
+	int i, j, rtest, srcs;
+	void *buf;
+	u8 g1[TEST_SOURCES], g2[TEST_SOURCES], g3[TEST_SOURCES];
+	u8 g4[TEST_SOURCES], g_tbls[4 * TEST_SOURCES * 32], *buffs[TEST_SOURCES];
+	u8 *dest1, *dest2, *dest3, *dest4, *dest_ref1, *dest_ref2, *dest_ref3;
+	u8 *dest_ref4, *dest_ptrs[4];
+
+	int align, size;
+	unsigned char *efence_buffs[TEST_SOURCES];
+	unsigned int offset;
+	u8 *ubuffs[TEST_SOURCES];
+	u8 *udest_ptrs[4];
+	printf(xstr(FUNCTION_UNDER_TEST) ": %dx%d ", TEST_SOURCES, TEST_LEN);
+
+	// Allocate the arrays
+	for (i = 0; i < TEST_SOURCES; i++) {
+		if (posix_memalign(&buf, 64, TEST_LEN)) {
+			printf("alloc error: Fail");
+			return -1;
+		}
+		buffs[i] = buf;
+	}
+
+	if (posix_memalign(&buf, 64, TEST_LEN)) {
+		printf("alloc error: Fail");
+		return -1;
+	}
+	dest1 = buf;
+
+	if (posix_memalign(&buf, 64, TEST_LEN)) {
+		printf("alloc error: Fail");
+		return -1;
+	}
+	dest2 = buf;
+
+	if (posix_memalign(&buf, 64, TEST_LEN)) {
+		printf("alloc error: Fail");
+		return -1;
+	}
+	dest3 = buf;
+
+	if (posix_memalign(&buf, 64, TEST_LEN)) {
+		printf("alloc error: Fail");
+		return -1;
+	}
+	dest4 = buf;
+
+	if (posix_memalign(&buf, 64, TEST_LEN)) {
+		printf("alloc error: Fail");
+		return -1;
+	}
+	dest_ref1 = buf;
+
+	if (posix_memalign(&buf, 64, TEST_LEN)) {
+		printf("alloc error: Fail");
+		return -1;
+	}
+	dest_ref2 = buf;
+
+	if (posix_memalign(&buf, 64, TEST_LEN)) {
+		printf("alloc error: Fail");
+		return -1;
+	}
+	dest_ref3 = buf;
+
+	if (posix_memalign(&buf, 64, TEST_LEN)) {
+		printf("alloc error: Fail");
+		return -1;
+	}
+	dest_ref4 = buf;
+
+	dest_ptrs[0] = dest1;
+	dest_ptrs[1] = dest2;
+	dest_ptrs[2] = dest3;
+	dest_ptrs[3] = dest4;
+
+	// Test of all zeros
+	for (i = 0; i < TEST_SOURCES; i++)
+		memset(buffs[i], 0, TEST_LEN);
+
+	memset(dest1, 0, TEST_LEN);
+	memset(dest2, 0, TEST_LEN);
+	memset(dest3, 0, TEST_LEN);
+	memset(dest4, 0, TEST_LEN);
+	memset(dest_ref1, 0, TEST_LEN);
+	memset(dest_ref2, 0, TEST_LEN);
+	memset(dest_ref3, 0, TEST_LEN);
+	memset(dest_ref4, 0, TEST_LEN);
+	memset(g1, 2, TEST_SOURCES);
+	memset(g2, 1, TEST_SOURCES);
+	memset(g3, 7, TEST_SOURCES);
+	memset(g4, 3, TEST_SOURCES);
+
+	for (i = 0; i < TEST_SOURCES; i++) {
+		gf_vect_mul_init(g1[i], &g_tbls[i * 32]);
+		gf_vect_mul_init(g2[i], &g_tbls[32 * TEST_SOURCES + i * 32]);
+		gf_vect_mul_init(g3[i], &g_tbls[64 * TEST_SOURCES + i * 32]);
+		gf_vect_mul_init(g4[i], &g_tbls[96 * TEST_SOURCES + i * 32]);
+	}
+
+	gf_vect_dot_prod_base(TEST_LEN, TEST_SOURCES, &g_tbls[0], buffs, dest_ref1);
+	gf_vect_dot_prod_base(TEST_LEN, TEST_SOURCES, &g_tbls[32 * TEST_SOURCES], buffs,
+			      dest_ref2);
+	gf_vect_dot_prod_base(TEST_LEN, TEST_SOURCES, &g_tbls[64 * TEST_SOURCES], buffs,
+			      dest_ref3);
+	gf_vect_dot_prod_base(TEST_LEN, TEST_SOURCES, &g_tbls[96 * TEST_SOURCES], buffs,
+			      dest_ref4);
+
+	FUNCTION_UNDER_TEST(TEST_LEN, TEST_SOURCES, g_tbls, buffs, dest_ptrs);
+
+	if (0 != memcmp(dest_ref1, dest1, TEST_LEN)) {
+		printf("Fail zero " xstr(FUNCTION_UNDER_TEST) " test1\n");
+		dump_matrix(buffs, 5, TEST_SOURCES);
+		printf("dprod_base:");
+		dump(dest_ref1, 25);
+		printf("dprod_dut:");
+		dump(dest1, 25);
+		return -1;
+	}
+	if (0 != memcmp(dest_ref2, dest2, TEST_LEN)) {
+		printf("Fail zero " xstr(FUNCTION_UNDER_TEST) " test2\n");
+		dump_matrix(buffs, 5, TEST_SOURCES);
+		printf("dprod_base:");
+		dump(dest_ref2, 25);
+		printf("dprod_dut:");
+		dump(dest2, 25);
+		return -1;
+	}
+	if (0 != memcmp(dest_ref3, dest3, TEST_LEN)) {
+		printf("Fail zero " xstr(FUNCTION_UNDER_TEST) " test3\n");
+		dump_matrix(buffs, 5, TEST_SOURCES);
+		printf("dprod_base:");
+		dump(dest_ref3, 25);
+		printf("dprod_dut:");
+		dump(dest3, 25);
+		return -1;
+	}
+	if (0 != memcmp(dest_ref4, dest4, TEST_LEN)) {
+		printf("Fail zero " xstr(FUNCTION_UNDER_TEST) " test4\n");
+		dump_matrix(buffs, 5, TEST_SOURCES);
+		printf("dprod_base:");
+		dump(dest_ref4, 25);
+		printf("dprod_dut:");
+		dump(dest4, 25);
+		return -1;
+	}
+
+	putchar('.');
+
+	// Rand data test
+
+	for (rtest = 0; rtest < RANDOMS; rtest++) {
+		for (i = 0; i < TEST_SOURCES; i++)
+			for (j = 0; j < TEST_LEN; j++)
+				buffs[i][j] = rand();
+
+		for (i = 0; i < TEST_SOURCES; i++) {
+			g1[i] = rand();
+			g2[i] = rand();
+			g3[i] = rand();
+			g4[i] = rand();
+		}
+
+		for (i = 0; i < TEST_SOURCES; i++) {
+			gf_vect_mul_init(g1[i], &g_tbls[i * 32]);
+			gf_vect_mul_init(g2[i], &g_tbls[(32 * TEST_SOURCES) + (i * 32)]);
+			gf_vect_mul_init(g3[i], &g_tbls[(64 * TEST_SOURCES) + (i * 32)]);
+			gf_vect_mul_init(g4[i], &g_tbls[(96 * TEST_SOURCES) + (i * 32)]);
+		}
+
+		gf_vect_dot_prod_base(TEST_LEN, TEST_SOURCES, &g_tbls[0], buffs, dest_ref1);
+		gf_vect_dot_prod_base(TEST_LEN, TEST_SOURCES, &g_tbls[32 * TEST_SOURCES],
+				      buffs, dest_ref2);
+		gf_vect_dot_prod_base(TEST_LEN, TEST_SOURCES, &g_tbls[64 * TEST_SOURCES],
+				      buffs, dest_ref3);
+		gf_vect_dot_prod_base(TEST_LEN, TEST_SOURCES, &g_tbls[96 * TEST_SOURCES],
+				      buffs, dest_ref4);
+
+		FUNCTION_UNDER_TEST(TEST_LEN, TEST_SOURCES, g_tbls, buffs, dest_ptrs);
+
+		if (0 != memcmp(dest_ref1, dest1, TEST_LEN)) {
+			printf("Fail rand " xstr(FUNCTION_UNDER_TEST) " test1 %d\n", rtest);
+			dump_matrix(buffs, 5, TEST_SOURCES);
+			printf("dprod_base:");
+			dump(dest_ref1, 25);
+			printf("dprod_dut:");
+			dump(dest1, 25);
+			return -1;
+		}
+		if (0 != memcmp(dest_ref2, dest2, TEST_LEN)) {
+			printf("Fail rand " xstr(FUNCTION_UNDER_TEST) " test2 %d\n", rtest);
+			dump_matrix(buffs, 5, TEST_SOURCES);
+			printf("dprod_base:");
+			dump(dest_ref2, 25);
+			printf("dprod_dut:");
+			dump(dest2, 25);
+			return -1;
+		}
+		if (0 != memcmp(dest_ref3, dest3, TEST_LEN)) {
+			printf("Fail rand " xstr(FUNCTION_UNDER_TEST) " test3 %d\n", rtest);
+			dump_matrix(buffs, 5, TEST_SOURCES);
+			printf("dprod_base:");
+			dump(dest_ref3, 25);
+			printf("dprod_dut:");
+			dump(dest3, 25);
+			return -1;
+		}
+		if (0 != memcmp(dest_ref4, dest4, TEST_LEN)) {
+			printf("Fail rand " xstr(FUNCTION_UNDER_TEST) " test4 %d\n", rtest);
+			dump_matrix(buffs, 5, TEST_SOURCES);
+			printf("dprod_base:");
+			dump(dest_ref4, 25);
+			printf("dprod_dut:");
+			dump(dest4, 25);
+			return -1;
+		}
+
+		putchar('.');
+	}
+
+	// Rand data test with varied parameters
+	for (rtest = 0; rtest < RANDOMS; rtest++) {
+		for (srcs = TEST_SOURCES; srcs > 0; srcs--) {
+			for (i = 0; i < srcs; i++)
+				for (j = 0; j < TEST_LEN; j++)
+					buffs[i][j] = rand();
+
+			for (i = 0; i < srcs; i++) {
+				g1[i] = rand();
+				g2[i] = rand();
+				g3[i] = rand();
+				g4[i] = rand();
+			}
+
+			for (i = 0; i < srcs; i++) {
+				gf_vect_mul_init(g1[i], &g_tbls[i * 32]);
+				gf_vect_mul_init(g2[i], &g_tbls[(32 * srcs) + (i * 32)]);
+				gf_vect_mul_init(g3[i], &g_tbls[(64 * srcs) + (i * 32)]);
+				gf_vect_mul_init(g4[i], &g_tbls[(96 * srcs) + (i * 32)]);
+			}
+
+			gf_vect_dot_prod_base(TEST_LEN, srcs, &g_tbls[0], buffs, dest_ref1);
+			gf_vect_dot_prod_base(TEST_LEN, srcs, &g_tbls[32 * srcs], buffs,
+					      dest_ref2);
+			gf_vect_dot_prod_base(TEST_LEN, srcs, &g_tbls[64 * srcs], buffs,
+					      dest_ref3);
+			gf_vect_dot_prod_base(TEST_LEN, srcs, &g_tbls[96 * srcs], buffs,
+					      dest_ref4);
+
+			FUNCTION_UNDER_TEST(TEST_LEN, srcs, g_tbls, buffs, dest_ptrs);
+
+			if (0 != memcmp(dest_ref1, dest1, TEST_LEN)) {
+				printf("Fail rand " xstr(FUNCTION_UNDER_TEST)
+				       " test1 srcs=%d\n", srcs);
+				dump_matrix(buffs, 5, TEST_SOURCES);
+				printf("dprod_base:");
+				dump(dest_ref1, 25);
+				printf("dprod_dut:");
+				dump(dest1, 25);
+				return -1;
+			}
+			if (0 != memcmp(dest_ref2, dest2, TEST_LEN)) {
+				printf("Fail rand " xstr(FUNCTION_UNDER_TEST)
+				       " test2 srcs=%d\n", srcs);
+				dump_matrix(buffs, 5, TEST_SOURCES);
+				printf("dprod_base:");
+				dump(dest_ref2, 25);
+				printf("dprod_dut:");
+				dump(dest2, 25);
+				return -1;
+			}
+			if (0 != memcmp(dest_ref3, dest3, TEST_LEN)) {
+				printf("Fail rand " xstr(FUNCTION_UNDER_TEST)
+				       " test3 srcs=%d\n", srcs);
+				dump_matrix(buffs, 5, TEST_SOURCES);
+				printf("dprod_base:");
+				dump(dest_ref3, 25);
+				printf("dprod_dut:");
+				dump(dest3, 25);
+				return -1;
+			}
+			if (0 != memcmp(dest_ref4, dest4, TEST_LEN)) {
+				printf("Fail rand " xstr(FUNCTION_UNDER_TEST)
+				       " test4 srcs=%d\n", srcs);
+				dump_matrix(buffs, 5, TEST_SOURCES);
+				printf("dprod_base:");
+				dump(dest_ref4, 25);
+				printf("dprod_dut:");
+				dump(dest4, 25);
+				return -1;
+			}
+
+			putchar('.');
+		}
+	}
+
+	// Run tests at end of buffer for Electric Fence
+	align = (LEN_ALIGN_CHK_B != 0) ? 1 : 32;
+	for (size = TEST_MIN_SIZE; size <= TEST_SIZE; size += align) {
+		for (i = 0; i < TEST_SOURCES; i++)
+			for (j = 0; j < TEST_LEN; j++)
+				buffs[i][j] = rand();
+
+		for (i = 0; i < TEST_SOURCES; i++)	// Line up TEST_SIZE from end
+			efence_buffs[i] = buffs[i] + TEST_LEN - size;
+
+		for (i = 0; i < TEST_SOURCES; i++) {
+			g1[i] = rand();
+			g2[i] = rand();
+			g3[i] = rand();
+			g4[i] = rand();
+		}
+
+		for (i = 0; i < TEST_SOURCES; i++) {
+			gf_vect_mul_init(g1[i], &g_tbls[i * 32]);
+			gf_vect_mul_init(g2[i], &g_tbls[(32 * TEST_SOURCES) + (i * 32)]);
+			gf_vect_mul_init(g3[i], &g_tbls[(64 * TEST_SOURCES) + (i * 32)]);
+			gf_vect_mul_init(g4[i], &g_tbls[(96 * TEST_SOURCES) + (i * 32)]);
+		}
+
+		gf_vect_dot_prod_base(size, TEST_SOURCES, &g_tbls[0], efence_buffs, dest_ref1);
+		gf_vect_dot_prod_base(size, TEST_SOURCES, &g_tbls[32 * TEST_SOURCES],
+				      efence_buffs, dest_ref2);
+		gf_vect_dot_prod_base(size, TEST_SOURCES, &g_tbls[64 * TEST_SOURCES],
+				      efence_buffs, dest_ref3);
+		gf_vect_dot_prod_base(size, TEST_SOURCES, &g_tbls[96 * TEST_SOURCES],
+				      efence_buffs, dest_ref4);
+
+		FUNCTION_UNDER_TEST(size, TEST_SOURCES, g_tbls, efence_buffs, dest_ptrs);
+
+		if (0 != memcmp(dest_ref1, dest1, size)) {
+			printf("Fail rand " xstr(FUNCTION_UNDER_TEST) " test1 %d\n", rtest);
+			dump_matrix(efence_buffs, 5, TEST_SOURCES);
+			printf("dprod_base:");
+			dump(dest_ref1, align);
+			printf("dprod_dut:");
+			dump(dest1, align);
+			return -1;
+		}
+
+		if (0 != memcmp(dest_ref2, dest2, size)) {
+			printf("Fail rand " xstr(FUNCTION_UNDER_TEST) " test2 %d\n", rtest);
+			dump_matrix(efence_buffs, 5, TEST_SOURCES);
+			printf("dprod_base:");
+			dump(dest_ref2, align);
+			printf("dprod_dut:");
+			dump(dest2, align);
+			return -1;
+		}
+
+		if (0 != memcmp(dest_ref3, dest3, size)) {
+			printf("Fail rand " xstr(FUNCTION_UNDER_TEST) " test3 %d\n", rtest);
+			dump_matrix(efence_buffs, 5, TEST_SOURCES);
+			printf("dprod_base:");
+			dump(dest_ref3, align);
+			printf("dprod_dut:");
+			dump(dest3, align);
+			return -1;
+		}
+
+		if (0 != memcmp(dest_ref4, dest4, size)) {
+			printf("Fail rand " xstr(FUNCTION_UNDER_TEST) " test4 %d\n", rtest);
+			dump_matrix(efence_buffs, 5, TEST_SOURCES);
+			printf("dprod_base:");
+			dump(dest_ref4, align);
+			printf("dprod_dut:");
+			dump(dest4, align);
+			return -1;
+		}
+
+		putchar('.');
+	}
+
+	// Test rand ptr alignment if available
+
+	for (rtest = 0; rtest < RANDOMS; rtest++) {
+		size = (TEST_LEN - PTR_ALIGN_CHK_B) & ~(TEST_MIN_SIZE - 1);
+		srcs = rand() % TEST_SOURCES;
+		if (srcs == 0)
+			continue;
+
+		offset = (PTR_ALIGN_CHK_B != 0) ? 1 : PTR_ALIGN_CHK_B;
+		// Add random offsets
+		for (i = 0; i < srcs; i++)
+			ubuffs[i] = buffs[i] + (rand() & (PTR_ALIGN_CHK_B - offset));
+
+		udest_ptrs[0] = dest1 + (rand() & (PTR_ALIGN_CHK_B - offset));
+		udest_ptrs[1] = dest2 + (rand() & (PTR_ALIGN_CHK_B - offset));
+		udest_ptrs[2] = dest3 + (rand() & (PTR_ALIGN_CHK_B - offset));
+		udest_ptrs[3] = dest4 + (rand() & (PTR_ALIGN_CHK_B - offset));
+
+		memset(dest1, 0, TEST_LEN);	// zero pad to check write-over
+		memset(dest2, 0, TEST_LEN);
+		memset(dest3, 0, TEST_LEN);
+		memset(dest4, 0, TEST_LEN);
+
+		for (i = 0; i < srcs; i++)
+			for (j = 0; j < size; j++)
+				ubuffs[i][j] = rand();
+
+		for (i = 0; i < srcs; i++) {
+			g1[i] = rand();
+			g2[i] = rand();
+			g3[i] = rand();
+			g4[i] = rand();
+		}
+
+		for (i = 0; i < srcs; i++) {
+			gf_vect_mul_init(g1[i], &g_tbls[i * 32]);
+			gf_vect_mul_init(g2[i], &g_tbls[(32 * srcs) + (i * 32)]);
+			gf_vect_mul_init(g3[i], &g_tbls[(64 * srcs) + (i * 32)]);
+			gf_vect_mul_init(g4[i], &g_tbls[(96 * srcs) + (i * 32)]);
+		}
+
+		gf_vect_dot_prod_base(size, srcs, &g_tbls[0], ubuffs, dest_ref1);
+		gf_vect_dot_prod_base(size, srcs, &g_tbls[32 * srcs], ubuffs, dest_ref2);
+		gf_vect_dot_prod_base(size, srcs, &g_tbls[64 * srcs], ubuffs, dest_ref3);
+		gf_vect_dot_prod_base(size, srcs, &g_tbls[96 * srcs], ubuffs, dest_ref4);
+
+		FUNCTION_UNDER_TEST(size, srcs, g_tbls, ubuffs, udest_ptrs);
+
+		if (memcmp(dest_ref1, udest_ptrs[0], size)) {
+			printf("Fail rand " xstr(FUNCTION_UNDER_TEST) " test ualign srcs=%d\n",
+			       srcs);
+			dump_matrix(ubuffs, 5, TEST_SOURCES);
+			printf("dprod_base:");
+			dump(dest_ref1, 25);
+			printf("dprod_dut:");
+			dump(udest_ptrs[0], 25);
+			return -1;
+		}
+		if (memcmp(dest_ref2, udest_ptrs[1], size)) {
+			printf("Fail rand " xstr(FUNCTION_UNDER_TEST) " test ualign srcs=%d\n",
+			       srcs);
+			dump_matrix(ubuffs, 5, TEST_SOURCES);
+			printf("dprod_base:");
+			dump(dest_ref2, 25);
+			printf("dprod_dut:");
+			dump(udest_ptrs[1], 25);
+			return -1;
+		}
+		if (memcmp(dest_ref3, udest_ptrs[2], size)) {
+			printf("Fail rand " xstr(FUNCTION_UNDER_TEST) " test ualign srcs=%d\n",
+			       srcs);
+			dump_matrix(ubuffs, 5, TEST_SOURCES);
+			printf("dprod_base:");
+			dump(dest_ref3, 25);
+			printf("dprod_dut:");
+			dump(udest_ptrs[2], 25);
+			return -1;
+		}
+		if (memcmp(dest_ref4, udest_ptrs[3], size)) {
+			printf("Fail rand " xstr(FUNCTION_UNDER_TEST) " test ualign srcs=%d\n",
+			       srcs);
+			dump_matrix(ubuffs, 5, TEST_SOURCES);
+			printf("dprod_base:");
+			dump(dest_ref4, 25);
+			printf("dprod_dut:");
+			dump(udest_ptrs[3], 25);
+			return -1;
+		}
+		// Confirm that padding around dests is unchanged
+		memset(dest_ref1, 0, PTR_ALIGN_CHK_B);	// Make reference zero buff
+		offset = udest_ptrs[0] - dest1;
+
+		if (memcmp(dest1, dest_ref1, offset)) {
+			printf("Fail rand ualign pad1 start\n");
+			return -1;
+		}
+		if (memcmp(dest1 + offset + size, dest_ref1, PTR_ALIGN_CHK_B - offset)) {
+			printf("Fail rand ualign pad1 end\n");
+			printf("size=%d offset=%d srcs=%d\n", size, offset, srcs);
+			return -1;
+		}
+
+		offset = udest_ptrs[1] - dest2;
+		if (memcmp(dest2, dest_ref1, offset)) {
+			printf("Fail rand ualign pad2 start\n");
+			return -1;
+		}
+		if (memcmp(dest2 + offset + size, dest_ref1, PTR_ALIGN_CHK_B - offset)) {
+			printf("Fail rand ualign pad2 end\n");
+			return -1;
+		}
+
+		offset = udest_ptrs[2] - dest3;
+		if (memcmp(dest3, dest_ref1, offset)) {
+			printf("Fail rand ualign pad3 start\n");
+			return -1;
+		}
+		if (memcmp(dest3 + offset + size, dest_ref1, PTR_ALIGN_CHK_B - offset)) {
+			printf("Fail rand ualign pad3 end\n");
+			return -1;
+		}
+
+		offset = udest_ptrs[3] - dest4;
+		if (memcmp(dest4, dest_ref1, offset)) {
+			printf("Fail rand ualign pad4 start\n");
+			return -1;
+		}
+		if (memcmp(dest4 + offset + size, dest_ref1, PTR_ALIGN_CHK_B - offset)) {
+			printf("Fail rand ualign pad4 end\n");
+			return -1;
+		}
+
+		putchar('.');
+	}
+
+	// Test all size alignment
+	align = (LEN_ALIGN_CHK_B != 0) ? 1 : 32;
+
+	for (size = TEST_LEN; size >= TEST_MIN_SIZE; size -= align) {
+		srcs = TEST_SOURCES;
+
+		for (i = 0; i < srcs; i++)
+			for (j = 0; j < size; j++)
+				buffs[i][j] = rand();
+
+		for (i = 0; i < srcs; i++) {
+			g1[i] = rand();
+			g2[i] = rand();
+			g3[i] = rand();
+			g4[i] = rand();
+		}
+
+		for (i = 0; i < srcs; i++) {
+			gf_vect_mul_init(g1[i], &g_tbls[i * 32]);
+			gf_vect_mul_init(g2[i], &g_tbls[(32 * srcs) + (i * 32)]);
+			gf_vect_mul_init(g3[i], &g_tbls[(64 * srcs) + (i * 32)]);
+			gf_vect_mul_init(g4[i], &g_tbls[(96 * srcs) + (i * 32)]);
+		}
+
+		gf_vect_dot_prod_base(size, srcs, &g_tbls[0], buffs, dest_ref1);
+		gf_vect_dot_prod_base(size, srcs, &g_tbls[32 * srcs], buffs, dest_ref2);
+		gf_vect_dot_prod_base(size, srcs, &g_tbls[64 * srcs], buffs, dest_ref3);
+		gf_vect_dot_prod_base(size, srcs, &g_tbls[96 * srcs], buffs, dest_ref4);
+
+		FUNCTION_UNDER_TEST(size, srcs, g_tbls, buffs, dest_ptrs);
+
+		if (memcmp(dest_ref1, dest_ptrs[0], size)) {
+			printf("Fail rand " xstr(FUNCTION_UNDER_TEST) " test ualign len=%d\n",
+			       size);
+			dump_matrix(buffs, 5, TEST_SOURCES);
+			printf("dprod_base:");
+			dump(dest_ref1, 25);
+			printf("dprod_dut:");
+			dump(dest_ptrs[0], 25);
+			return -1;
+		}
+		if (memcmp(dest_ref2, dest_ptrs[1], size)) {
+			printf("Fail rand " xstr(FUNCTION_UNDER_TEST) " test ualign len=%d\n",
+			       size);
+			dump_matrix(buffs, 5, TEST_SOURCES);
+			printf("dprod_base:");
+			dump(dest_ref2, 25);
+			printf("dprod_dut:");
+			dump(dest_ptrs[1], 25);
+			return -1;
+		}
+		if (memcmp(dest_ref3, dest_ptrs[2], size)) {
+			printf("Fail rand " xstr(FUNCTION_UNDER_TEST) " test ualign len=%d\n",
+			       size);
+			dump_matrix(buffs, 5, TEST_SOURCES);
+			printf("dprod_base:");
+			dump(dest_ref3, 25);
+			printf("dprod_dut:");
+			dump(dest_ptrs[2], 25);
+			return -1;
+		}
+		if (memcmp(dest_ref4, dest_ptrs[3], size)) {
+			printf("Fail rand " xstr(FUNCTION_UNDER_TEST) " test ualign len=%d\n",
+			       size);
+			dump_matrix(buffs, 5, TEST_SOURCES);
+			printf("dprod_base:");
+			dump(dest_ref4, 25);
+			printf("dprod_dut:");
+			dump(dest_ptrs[3], 25);
+			return -1;
+		}
+	}
+
+	printf("Pass\n");
+	return 0;
+
+}

--- a/erasure_code/loongarch64/gf_4vect_mad_lasx.c
+++ b/erasure_code/loongarch64/gf_4vect_mad_lasx.c
@@ -1,0 +1,217 @@
+/**********************************************************************
+  Copyright(c) 2022 Loongson Tech All rights reserved.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions
+  are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in
+      the documentation and/or other materials provided with the
+      distribution.
+    * Neither the name of Intel Corporation nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+**********************************************************************/
+
+#include <lasxintrin.h>
+
+void gf_4vect_mad_lasx(int len, int vec, int vec_i, unsigned char *gftbls,
+		       unsigned char *src, unsigned char **dest)
+{
+	int i, l;
+	int skip1 = vec << 5;
+	int skip2 = skip1 << 1;
+	int skip3 = skip1 + skip2;
+
+	int block_count = len >> 5;
+	int remain = len - (block_count << 5);
+	int buf_offset = 0, col_offset = vec_i << 5;
+
+	__m256i block, high_idx, low_idx;
+	__m256i high_elem, low_elem;
+       	__m256i	high_val, low_val;
+	__m256i res;
+
+	unsigned long index, tmp, tmp1;
+	unsigned char *pos;
+	unsigned char sval;
+
+	for (i = 0; i < block_count; ++i) {
+		/* read one block from src to update four rows */
+
+		buf_offset = i << 5;
+		// fetch one block from one buf into a vector variable,
+		// the block size is 32 bytes
+		block = __lasx_xvldx(src, buf_offset);
+
+		// get low indexes
+		low_idx = __lasx_xvandi_b(block, 0x0F);
+
+		// get high indexes: shift right 4 bits and add 0x10,
+		// which can index {0x10, ..., 0x1F}
+		high_idx = __lasx_xvori_b(__lasx_xvsrli_b(block, 4), 0x10);
+
+		/* =================== for row 0 =================== */
+		// fetch one element from gftbls, which is 32 bytes
+		low_elem = __lasx_xvldx(gftbls, col_offset);
+		high_elem = low_elem;
+
+		// duplicate low part
+		low_elem = __lasx_xvpermi_d(low_elem, 0x44);
+
+		// duplicate high part
+		high_elem = __lasx_xvpermi_d(high_elem, 0xEE);
+
+		// pick by low_idx
+		low_val = __lasx_xvshuf_b(low_elem, low_elem, low_idx);
+
+		// pick by high_idx
+		high_val = __lasx_xvshuf_b(high_elem, high_elem, high_idx);
+
+		// load old data
+		res = __lasx_xvldx(dest[0], buf_offset);
+
+		// accumulation on GF(2^8)
+		res = __lasx_xvxor_v(res, __lasx_xvxor_v(low_val, high_val));
+
+		// store new data
+		__lasx_xvstx(res, dest[0], buf_offset);
+
+		/* =================== for row 1 =================== */
+		// fetch one element from gftbls, which is 32 bytes
+		low_elem = __lasx_xvldx(gftbls, col_offset + skip1);
+		high_elem = low_elem;
+
+		// duplicate low part
+		low_elem = __lasx_xvpermi_d(low_elem, 0x44);
+
+		// duplicate high part
+		high_elem = __lasx_xvpermi_d(high_elem, 0xEE);
+
+		// pick by low_idx
+		low_val = __lasx_xvshuf_b(low_elem, low_elem, low_idx);
+
+		// pick by high_idx
+		high_val = __lasx_xvshuf_b(high_elem, high_elem, high_idx);
+
+		// load old data
+		res = __lasx_xvldx(dest[1], buf_offset);
+
+		// accumulation on GF(2^8)
+		res = __lasx_xvxor_v(res, __lasx_xvxor_v(low_val, high_val));
+
+		// store new data
+		__lasx_xvstx(res, dest[1], buf_offset);
+
+		/* =================== for row 2 =================== */
+		// fetch one element from gftbls, which is 32 bytes
+		low_elem = __lasx_xvldx(gftbls, col_offset + skip2);
+		high_elem = low_elem;
+
+		// duplicate low part
+		low_elem = __lasx_xvpermi_d(low_elem, 0x44);
+
+		// duplicate high part
+		high_elem = __lasx_xvpermi_d(high_elem, 0xEE);
+
+		// pick by low_idx
+		low_val = __lasx_xvshuf_b(low_elem, low_elem, low_idx);
+
+		// pick by high_idx
+		high_val = __lasx_xvshuf_b(high_elem, high_elem, high_idx);
+
+		// load old data
+		res = __lasx_xvldx(dest[2], buf_offset);
+
+		// accumulation on GF(2^8)
+		res = __lasx_xvxor_v(res, __lasx_xvxor_v(low_val, high_val));
+
+		// store new data
+		__lasx_xvstx(res, dest[2], buf_offset);
+
+		/* =================== for row 3 =================== */
+		// fetch one element from gftbls, which is 32 bytes
+		low_elem = __lasx_xvldx(gftbls, col_offset + skip3);
+		high_elem = low_elem;
+
+		// duplicate low part
+		low_elem = __lasx_xvpermi_d(low_elem, 0x44);
+
+		// duplicate high part
+		high_elem = __lasx_xvpermi_d(high_elem, 0xEE);
+
+		// pick by low_idx
+		low_val = __lasx_xvshuf_b(low_elem, low_elem, low_idx);
+
+		// pick by high_idx
+		high_val = __lasx_xvshuf_b(high_elem, high_elem, high_idx);
+
+		// load old data
+		res = __lasx_xvldx(dest[3], buf_offset);
+
+		// accumulation on GF(2^8)
+		res = __lasx_xvxor_v(res, __lasx_xvxor_v(low_val, high_val));
+
+		// store new data
+		__lasx_xvstx(res, dest[3], buf_offset);
+	}
+
+	if (remain == 0)
+		return;
+
+	// handle remain bytes
+	i = block_count << 5;
+	while (remain >= 8) {
+		tmp1 = *(unsigned long *)&src[i];
+		for (l = 0; l < 4; ++l) {
+			index = tmp1;
+			pos = &gftbls[col_offset + l * skip1];
+
+			tmp = pos[index & 0xF] ^ pos[16 + ((index >> 4) & 0xF)];
+			index = index >> 8;
+			tmp |= (unsigned long)(pos[index & 0xF] ^ pos[16 + ((index >> 4) & 0xF)]) << 8;
+			index = index >> 8;
+			tmp |= (unsigned long)(pos[index & 0xF] ^ pos[16 + ((index >> 4) & 0xF)]) << 16;
+			index = index >> 8;
+			tmp |= (unsigned long)(pos[index & 0xF] ^ pos[16 + ((index >> 4) & 0xF)]) << 24;
+			index = index >> 8;
+			tmp |= (unsigned long)(pos[index & 0xF] ^ pos[16 + ((index >> 4) & 0xF)]) << 32;
+			index = index >> 8;
+			tmp |= (unsigned long)(pos[index & 0xF] ^ pos[16 + ((index >> 4) & 0xF)]) << 40;
+			index = index >> 8;
+			tmp |= (unsigned long)(pos[index & 0xF] ^ pos[16 + ((index >> 4) & 0xF)]) << 48;
+			index = index >> 8;
+			tmp |= (unsigned long)(pos[index & 0xF] ^ pos[16 + ((index >> 4) & 0xF)]) << 56;
+
+			*(unsigned long *)&dest[l][i] ^= tmp;
+		}
+		i += sizeof(unsigned long);
+		remain -= sizeof(unsigned long);
+	}
+
+	if (remain == 0)
+		return;
+
+	buf_offset = i;
+	for (l = 0; l < 4; l++) {
+		for (i = buf_offset; i < len; i++) {
+			sval = src[i];
+			pos = &gftbls[col_offset + l * skip1];
+			dest[l][i] ^= pos[sval & 0xF] ^ pos[16 + (sval >> 4)];
+		}
+	}
+}

--- a/erasure_code/loongarch64/gf_4vect_mad_lasx_test.c
+++ b/erasure_code/loongarch64/gf_4vect_mad_lasx_test.c
@@ -1,0 +1,519 @@
+/**********************************************************************
+  Copyright(c) 2011-2015 Intel Corporation All rights reserved.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions
+  are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in
+      the documentation and/or other materials provided with the
+      distribution.
+    * Neither the name of Intel Corporation nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+**********************************************************************/
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>		// for memset, memcmp
+#include "erasure_code.h"
+#include "types.h"
+
+#ifndef ALIGN_SIZE
+# define ALIGN_SIZE 32
+#endif
+
+#ifndef FUNCTION_UNDER_TEST
+//By default, test multi-binary version
+# define FUNCTION_UNDER_TEST gf_4vect_mad_lasx
+# define REF_FUNCTION gf_4vect_dot_prod_lasx
+# define VECT 4
+#endif
+
+#ifndef TEST_MIN_SIZE
+# define TEST_MIN_SIZE 64
+#endif
+
+#define str(s) #s
+#define xstr(s) str(s)
+
+#define TEST_LEN (8192+31)
+#define TEST_SIZE (TEST_LEN/2)
+#define TEST_MEM  TEST_SIZE
+#define TEST_LOOPS 20000
+#define TEST_TYPE_STR ""
+
+#ifndef TEST_SOURCES
+# define TEST_SOURCES  16
+#endif
+#ifndef RANDOMS
+# define RANDOMS 20
+#endif
+
+#ifdef EC_ALIGNED_ADDR
+// Define power of 2 range to check ptr, len alignment
+# define PTR_ALIGN_CHK_B 0
+# define LEN_ALIGN_CHK_B 0	// 0 for aligned only
+#else
+// Define power of 2 range to check ptr, len alignment
+# define PTR_ALIGN_CHK_B ALIGN_SIZE
+# define LEN_ALIGN_CHK_B ALIGN_SIZE	// 0 for aligned only
+#endif
+
+#define str(s) #s
+#define xstr(s) str(s)
+
+typedef unsigned char u8;
+
+#if (VECT == 1)
+# define LAST_ARG *dest
+#else
+# define LAST_ARG **dest
+#endif
+
+extern void FUNCTION_UNDER_TEST(int len, int vec, int vec_i, unsigned char *gftbls,
+				unsigned char *src, unsigned char LAST_ARG);
+extern void REF_FUNCTION(int len, int vlen, unsigned char *gftbls, unsigned char **src,
+			 unsigned char LAST_ARG);
+
+void dump(unsigned char *buf, int len)
+{
+	int i;
+	for (i = 0; i < len;) {
+		printf(" %2x", 0xff & buf[i++]);
+		if (i % 32 == 0)
+			printf("\n");
+	}
+	printf("\n");
+}
+
+void dump_matrix(unsigned char **s, int k, int m)
+{
+	int i, j;
+	for (i = 0; i < k; i++) {
+		for (j = 0; j < m; j++) {
+			printf(" %2x", s[i][j]);
+		}
+		printf("\n");
+	}
+	printf("\n");
+}
+
+void dump_u8xu8(unsigned char *s, int k, int m)
+{
+	int i, j;
+	for (i = 0; i < k; i++) {
+		for (j = 0; j < m; j++) {
+			printf(" %2x", 0xff & s[j + (i * m)]);
+		}
+		printf("\n");
+	}
+	printf("\n");
+}
+
+int main(int argc, char *argv[])
+{
+	int i, j, rtest, srcs;
+	void *buf;
+	u8 gf[6][TEST_SOURCES];
+	u8 *g_tbls;
+	u8 *dest_ref[VECT];
+	u8 *dest_ptrs[VECT], *buffs[TEST_SOURCES];
+	int vector = VECT;
+
+	int align, size;
+	unsigned char *efence_buffs[TEST_SOURCES];
+	unsigned int offset;
+	u8 *ubuffs[TEST_SOURCES];
+	u8 *udest_ptrs[VECT];
+	printf("test" xstr(FUNCTION_UNDER_TEST) ": %dx%d ", TEST_SOURCES, TEST_LEN);
+
+	// Allocate the arrays
+	for (i = 0; i < TEST_SOURCES; i++) {
+		if (posix_memalign(&buf, 64, TEST_LEN)) {
+			printf("alloc error: Fail");
+			return -1;
+		}
+		buffs[i] = buf;
+	}
+
+	if (posix_memalign(&buf, 16, 2 * (vector * TEST_SOURCES * 32))) {
+		printf("alloc error: Fail");
+		return -1;
+	}
+	g_tbls = buf;
+
+	for (i = 0; i < vector; i++) {
+		if (posix_memalign(&buf, 64, TEST_LEN)) {
+			printf("alloc error: Fail");
+			return -1;
+		}
+		dest_ptrs[i] = buf;
+		memset(dest_ptrs[i], 0, TEST_LEN);
+	}
+
+	for (i = 0; i < vector; i++) {
+		if (posix_memalign(&buf, 64, TEST_LEN)) {
+			printf("alloc error: Fail");
+			return -1;
+		}
+		dest_ref[i] = buf;
+		memset(dest_ref[i], 0, TEST_LEN);
+	}
+
+	// Test of all zeros
+	for (i = 0; i < TEST_SOURCES; i++)
+		memset(buffs[i], 0, TEST_LEN);
+
+	switch (vector) {
+	case 6:
+		memset(gf[5], 0xe6, TEST_SOURCES);
+	case 5:
+		memset(gf[4], 4, TEST_SOURCES);
+	case 4:
+		memset(gf[3], 9, TEST_SOURCES);
+	case 3:
+		memset(gf[2], 7, TEST_SOURCES);
+	case 2:
+		memset(gf[1], 1, TEST_SOURCES);
+	case 1:
+		memset(gf[0], 2, TEST_SOURCES);
+		break;
+	default:
+		return -1;
+	}
+
+	for (i = 0; i < TEST_SOURCES; i++)
+		for (j = 0; j < TEST_LEN; j++)
+			buffs[i][j] = rand();
+
+	for (i = 0; i < vector; i++)
+		for (j = 0; j < TEST_SOURCES; j++) {
+			gf[i][j] = rand();
+			gf_vect_mul_init(gf[i][j], &g_tbls[i * (32 * TEST_SOURCES) + j * 32]);
+		}
+
+	for (i = 0; i < vector; i++)
+		gf_vect_dot_prod_base(TEST_LEN, TEST_SOURCES, &g_tbls[i * 32 * TEST_SOURCES],
+				      buffs, dest_ref[i]);
+
+	for (i = 0; i < vector; i++)
+		memset(dest_ptrs[i], 0, TEST_LEN);
+	for (i = 0; i < TEST_SOURCES; i++) {
+#if (VECT == 1)
+		FUNCTION_UNDER_TEST(TEST_LEN, TEST_SOURCES, i, g_tbls, buffs[i], *dest_ptrs);
+#else
+		FUNCTION_UNDER_TEST(TEST_LEN, TEST_SOURCES, i, g_tbls, buffs[i], dest_ptrs);
+#endif
+	}
+	for (i = 0; i < vector; i++) {
+		if (0 != memcmp(dest_ref[i], dest_ptrs[i], TEST_LEN)) {
+			printf("Fail zero " xstr(FUNCTION_UNDER_TEST) " test%d\n", i);
+			dump_matrix(buffs, vector, TEST_SOURCES);
+			printf("dprod_base:");
+			dump(dest_ref[i], 25);
+			printf("dprod_dut:");
+			dump(dest_ptrs[i], 25);
+			return -1;
+		}
+	}
+
+#if (VECT == 1)
+	REF_FUNCTION(TEST_LEN, TEST_SOURCES, g_tbls, buffs, *dest_ref);
+#else
+	REF_FUNCTION(TEST_LEN, TEST_SOURCES, g_tbls, buffs, dest_ref);
+#endif
+	for (i = 0; i < vector; i++) {
+		if (0 != memcmp(dest_ref[i], dest_ptrs[i], TEST_LEN)) {
+			printf("Fail zero " xstr(FUNCTION_UNDER_TEST) " test%d\n", i);
+			dump_matrix(buffs, vector, TEST_SOURCES);
+			printf("dprod_base:");
+			dump(dest_ref[i], 25);
+			printf("dprod_dut:");
+			dump(dest_ptrs[i], 25);
+			return -1;
+		}
+	}
+
+	putchar('.');
+
+	// Rand data test
+
+	for (rtest = 0; rtest < RANDOMS; rtest++) {
+		for (i = 0; i < TEST_SOURCES; i++)
+			for (j = 0; j < TEST_LEN; j++)
+				buffs[i][j] = rand();
+
+		for (i = 0; i < vector; i++)
+			for (j = 0; j < TEST_SOURCES; j++) {
+				gf[i][j] = rand();
+				gf_vect_mul_init(gf[i][j],
+						 &g_tbls[i * (32 * TEST_SOURCES) + j * 32]);
+			}
+
+		for (i = 0; i < vector; i++)
+			gf_vect_dot_prod_base(TEST_LEN, TEST_SOURCES,
+					      &g_tbls[i * 32 * TEST_SOURCES], buffs,
+					      dest_ref[i]);
+
+		for (i = 0; i < vector; i++)
+			memset(dest_ptrs[i], 0, TEST_LEN);
+		for (i = 0; i < TEST_SOURCES; i++) {
+#if (VECT == 1)
+			FUNCTION_UNDER_TEST(TEST_LEN, TEST_SOURCES, i, g_tbls, buffs[i],
+					    *dest_ptrs);
+#else
+			FUNCTION_UNDER_TEST(TEST_LEN, TEST_SOURCES, i, g_tbls, buffs[i],
+					    dest_ptrs);
+#endif
+		}
+		for (i = 0; i < vector; i++) {
+			if (0 != memcmp(dest_ref[i], dest_ptrs[i], TEST_LEN)) {
+				printf("Fail rand " xstr(FUNCTION_UNDER_TEST) " test%d %d\n",
+				       i, rtest);
+				dump_matrix(buffs, vector, TEST_SOURCES);
+				printf("dprod_base:");
+				dump(dest_ref[i], 25);
+				printf("dprod_dut:");
+				dump(dest_ptrs[i], 25);
+				return -1;
+			}
+		}
+
+		putchar('.');
+	}
+
+	// Rand data test with varied parameters
+	for (rtest = 0; rtest < RANDOMS; rtest++) {
+		for (srcs = TEST_SOURCES; srcs > 0; srcs--) {
+			for (i = 0; i < srcs; i++)
+				for (j = 0; j < TEST_LEN; j++)
+					buffs[i][j] = rand();
+
+			for (i = 0; i < vector; i++)
+				for (j = 0; j < srcs; j++) {
+					gf[i][j] = rand();
+					gf_vect_mul_init(gf[i][j],
+							 &g_tbls[i * (32 * srcs) + j * 32]);
+				}
+
+			for (i = 0; i < vector; i++)
+				gf_vect_dot_prod_base(TEST_LEN, srcs, &g_tbls[i * 32 * srcs],
+						      buffs, dest_ref[i]);
+
+			for (i = 0; i < vector; i++)
+				memset(dest_ptrs[i], 0, TEST_LEN);
+			for (i = 0; i < srcs; i++) {
+#if (VECT == 1)
+				FUNCTION_UNDER_TEST(TEST_LEN, srcs, i, g_tbls, buffs[i],
+						    *dest_ptrs);
+#else
+				FUNCTION_UNDER_TEST(TEST_LEN, srcs, i, g_tbls, buffs[i],
+						    dest_ptrs);
+#endif
+
+			}
+			for (i = 0; i < vector; i++) {
+				if (0 != memcmp(dest_ref[i], dest_ptrs[i], TEST_LEN)) {
+					printf("Fail rand " xstr(FUNCTION_UNDER_TEST)
+					       " test%d srcs=%d\n", i, srcs);
+					dump_matrix(buffs, vector, TEST_SOURCES);
+					printf("dprod_base:");
+					dump(dest_ref[i], 25);
+					printf("dprod_dut:");
+					dump(dest_ptrs[i], 25);
+					return -1;
+				}
+			}
+
+			putchar('.');
+		}
+	}
+
+	// Run tests at end of buffer for Electric Fence
+	align = (LEN_ALIGN_CHK_B != 0) ? 1 : ALIGN_SIZE;
+	for (size = TEST_MIN_SIZE; size <= TEST_SIZE; size += align) {
+		for (i = 0; i < TEST_SOURCES; i++)
+			for (j = 0; j < TEST_LEN; j++)
+				buffs[i][j] = rand();
+
+		for (i = 0; i < TEST_SOURCES; i++)	// Line up TEST_SIZE from end
+			efence_buffs[i] = buffs[i] + TEST_LEN - size;
+
+		for (i = 0; i < vector; i++)
+			for (j = 0; j < TEST_SOURCES; j++) {
+				gf[i][j] = rand();
+				gf_vect_mul_init(gf[i][j],
+						 &g_tbls[i * (32 * TEST_SOURCES) + j * 32]);
+			}
+
+		for (i = 0; i < vector; i++)
+			gf_vect_dot_prod_base(size, TEST_SOURCES,
+					      &g_tbls[i * 32 * TEST_SOURCES], efence_buffs,
+					      dest_ref[i]);
+
+		for (i = 0; i < vector; i++)
+			memset(dest_ptrs[i], 0, size);
+		for (i = 0; i < TEST_SOURCES; i++) {
+#if (VECT == 1)
+			FUNCTION_UNDER_TEST(size, TEST_SOURCES, i, g_tbls, efence_buffs[i],
+					    *dest_ptrs);
+#else
+			FUNCTION_UNDER_TEST(size, TEST_SOURCES, i, g_tbls, efence_buffs[i],
+					    dest_ptrs);
+#endif
+		}
+		for (i = 0; i < vector; i++) {
+			if (0 != memcmp(dest_ref[i], dest_ptrs[i], size)) {
+				printf("Fail rand " xstr(FUNCTION_UNDER_TEST)
+				       " test%d size=%d\n", i, size);
+				dump_matrix(buffs, vector, TEST_SOURCES);
+				printf("dprod_base:");
+				dump(dest_ref[i], TEST_MIN_SIZE + align);
+				printf("dprod_dut:");
+				dump(dest_ptrs[i], TEST_MIN_SIZE + align);
+				return -1;
+			}
+		}
+
+		putchar('.');
+	}
+
+	// Test rand ptr alignment if available
+
+	for (rtest = 0; rtest < RANDOMS; rtest++) {
+		size = (TEST_LEN - PTR_ALIGN_CHK_B) & ~(TEST_MIN_SIZE - 1);
+		srcs = rand() % TEST_SOURCES;
+		if (srcs == 0)
+			continue;
+
+		offset = (PTR_ALIGN_CHK_B != 0) ? 1 : PTR_ALIGN_CHK_B;
+		// Add random offsets
+		for (i = 0; i < srcs; i++)
+			ubuffs[i] = buffs[i] + (rand() & (PTR_ALIGN_CHK_B - offset));
+
+		for (i = 0; i < vector; i++) {
+			udest_ptrs[i] = dest_ptrs[i] + (rand() & (PTR_ALIGN_CHK_B - offset));
+			memset(dest_ptrs[i], 0, TEST_LEN);	// zero pad to check write-over
+		}
+
+		for (i = 0; i < srcs; i++)
+			for (j = 0; j < size; j++)
+				ubuffs[i][j] = rand();
+
+		for (i = 0; i < vector; i++)
+			for (j = 0; j < srcs; j++) {
+				gf[i][j] = rand();
+				gf_vect_mul_init(gf[i][j], &g_tbls[i * (32 * srcs) + j * 32]);
+			}
+
+		for (i = 0; i < vector; i++)
+			gf_vect_dot_prod_base(size, srcs, &g_tbls[i * 32 * srcs], ubuffs,
+					      dest_ref[i]);
+
+		for (i = 0; i < srcs; i++) {
+#if (VECT == 1)
+			FUNCTION_UNDER_TEST(size, srcs, i, g_tbls, ubuffs[i], *udest_ptrs);
+#else
+			FUNCTION_UNDER_TEST(size, srcs, i, g_tbls, ubuffs[i], udest_ptrs);
+#endif
+		}
+		for (i = 0; i < vector; i++) {
+			if (0 != memcmp(dest_ref[i], udest_ptrs[i], size)) {
+				printf("Fail rand " xstr(FUNCTION_UNDER_TEST)
+				       " test%d ualign srcs=%d\n", i, srcs);
+				dump_matrix(buffs, vector, TEST_SOURCES);
+				printf("dprod_base:");
+				dump(dest_ref[i], 25);
+				printf("dprod_dut:");
+				dump(udest_ptrs[i], 25);
+				return -1;
+			}
+		}
+
+		// Confirm that padding around dests is unchanged
+		memset(dest_ref[0], 0, PTR_ALIGN_CHK_B);	// Make reference zero buff
+
+		for (i = 0; i < vector; i++) {
+			offset = udest_ptrs[i] - dest_ptrs[i];
+			if (memcmp(dest_ptrs[i], dest_ref[0], offset)) {
+				printf("Fail rand ualign pad1 start\n");
+				return -1;
+			}
+			if (memcmp
+			    (dest_ptrs[i] + offset + size, dest_ref[0],
+			     PTR_ALIGN_CHK_B - offset)) {
+				printf("Fail rand ualign pad1 end\n");
+				return -1;
+			}
+		}
+
+		putchar('.');
+	}
+
+	// Test all size alignment
+	align = (LEN_ALIGN_CHK_B != 0) ? 1 : ALIGN_SIZE;
+
+	for (size = TEST_LEN; size >= TEST_MIN_SIZE; size -= align) {
+		for (i = 0; i < TEST_SOURCES; i++)
+			for (j = 0; j < size; j++)
+				buffs[i][j] = rand();
+
+		for (i = 0; i < vector; i++) {
+			for (j = 0; j < TEST_SOURCES; j++) {
+				gf[i][j] = rand();
+				gf_vect_mul_init(gf[i][j],
+						 &g_tbls[i * (32 * TEST_SOURCES) + j * 32]);
+			}
+			memset(dest_ptrs[i], 0, TEST_LEN);	// zero pad to check write-over
+		}
+
+		for (i = 0; i < vector; i++)
+			gf_vect_dot_prod_base(size, TEST_SOURCES,
+					      &g_tbls[i * 32 * TEST_SOURCES], buffs,
+					      dest_ref[i]);
+
+		for (i = 0; i < TEST_SOURCES; i++) {
+#if (VECT == 1)
+			FUNCTION_UNDER_TEST(size, TEST_SOURCES, i, g_tbls, buffs[i],
+					    *dest_ptrs);
+#else
+			FUNCTION_UNDER_TEST(size, TEST_SOURCES, i, g_tbls, buffs[i],
+					    dest_ptrs);
+#endif
+		}
+		for (i = 0; i < vector; i++) {
+			if (0 != memcmp(dest_ref[i], dest_ptrs[i], size)) {
+				printf("Fail rand " xstr(FUNCTION_UNDER_TEST)
+				       " test%d ualign len=%d\n", i, size);
+				dump_matrix(buffs, vector, TEST_SOURCES);
+				printf("dprod_base:");
+				dump(dest_ref[i], 25);
+				printf("dprod_dut:");
+				dump(dest_ptrs[i], 25);
+				return -1;
+			}
+		}
+
+		putchar('.');
+
+	}
+
+	printf("Pass\n");
+	return 0;
+
+}

--- a/erasure_code/loongarch64/gf_5vect_dot_prod_lasx.c
+++ b/erasure_code/loongarch64/gf_5vect_dot_prod_lasx.c
@@ -1,0 +1,236 @@
+/**********************************************************************
+  Copyright(c) 2022 Loongson Tech All rights reserved.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions
+  are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in
+      the documentation and/or other materials provided with the
+      distribution.
+    * Neither the name of Intel Corporation nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+**********************************************************************/
+
+#include <lasxintrin.h>
+
+void gf_5vect_dot_prod_lasx(int len, int vlen, unsigned char *gftbls,
+			    unsigned char **src, unsigned char **dest)
+{
+	int i, j, l;
+	int skip1 = vlen << 5;
+	int skip2 = skip1 << 1;
+	int skip3 = skip1 + skip2;
+
+	int block_count = len >> 5;
+	int remain = len - (block_count << 5);
+	int buf_offset = 0, col_offset = 0;
+
+	__m256i block, high_idx, low_idx;
+	__m256i high_elem, low_elem;
+       	__m256i	high_val, low_val;
+	__m256i res1, res2, res3, res4, res5;
+
+	unsigned long sul, index, tmp;
+	unsigned char *pos;
+	unsigned char suc, sval;
+
+	for (i = 0; i < block_count; ++i) {
+		res1 = __lasx_xvldi(0);
+		res2 = __lasx_xvldi(0);
+		res3 = __lasx_xvldi(0);
+		res4 = __lasx_xvldi(0);
+		res5 = __lasx_xvldi(0);
+
+		buf_offset = i << 5;
+		for (j = 0; j < vlen; ++j) {
+			/* read one block from one buf to update five rows */
+
+			col_offset = j << 5;
+
+			// fetch one block from one buf into a vector variable,
+			// the block size is 32 bytes
+			block = __lasx_xvldx(src[j], buf_offset);
+
+			// get low indexes
+			low_idx = __lasx_xvandi_b(block, 0x0F);
+
+			// get high indexes: shift right 4 bits and add 0x10,
+			// which can index {0x10, ..., 0x1F}
+			high_idx = __lasx_xvori_b(__lasx_xvsrli_b(block, 4), 0x10);
+
+			/* =================== for row 0 =================== */
+			// fetch one element from gftbls, which is 32 bytes
+			low_elem = __lasx_xvldx(gftbls, col_offset);
+			high_elem = low_elem;
+
+			// duplicate low part
+			low_elem = __lasx_xvpermi_d(low_elem, 0x44);
+
+			// duplicate high part
+			high_elem = __lasx_xvpermi_d(high_elem, 0xEE);
+
+			// pick by low_idx
+			low_val = __lasx_xvshuf_b(low_elem, low_elem, low_idx);
+
+			// pick by high_idx
+			high_val = __lasx_xvshuf_b(high_elem, high_elem, high_idx);
+
+			// accumulation on GF(2^8)
+			res1 = __lasx_xvxor_v(res1, __lasx_xvxor_v(low_val, high_val));
+
+			/* =================== for row 1 =================== */
+			// fetch one element from gftbls, which is 32 bytes
+			low_elem = __lasx_xvldx(gftbls, col_offset + skip1);
+			high_elem = low_elem;
+
+			// duplicate low part
+			low_elem = __lasx_xvpermi_d(low_elem, 0x44);
+
+			// duplicate high part
+			high_elem = __lasx_xvpermi_d(high_elem, 0xEE);
+
+			// pick by low_idx
+			low_val = __lasx_xvshuf_b(low_elem, low_elem, low_idx);
+
+			// pick by high_idx
+			high_val = __lasx_xvshuf_b(high_elem, high_elem, high_idx);
+
+			// accumulation on GF(2^8)
+			res2 = __lasx_xvxor_v(res2, __lasx_xvxor_v(low_val, high_val));
+
+			/* =================== for row 2 =================== */
+			// fetch one element from gftbls, which is 32 bytes
+			low_elem = __lasx_xvldx(gftbls, col_offset + skip2);
+			high_elem = low_elem;
+
+			// duplicate low part
+			low_elem = __lasx_xvpermi_d(low_elem, 0x44);
+
+			// duplicate high part
+			high_elem = __lasx_xvpermi_d(high_elem, 0xEE);
+
+			// pick by low_idx
+			low_val = __lasx_xvshuf_b(low_elem, low_elem, low_idx);
+
+			// pick by high_idx
+			high_val = __lasx_xvshuf_b(high_elem, high_elem, high_idx);
+
+			// accumulation on GF(2^8)
+			res3 = __lasx_xvxor_v(res3, __lasx_xvxor_v(low_val, high_val));
+
+			/* =================== for row 3 =================== */
+			// fetch one element from gftbls, which is 32 bytes
+			low_elem = __lasx_xvldx(gftbls, col_offset + skip3);
+			high_elem = low_elem;
+
+			// duplicate low part
+			low_elem = __lasx_xvpermi_d(low_elem, 0x44);
+
+			// duplicate high part
+			high_elem = __lasx_xvpermi_d(high_elem, 0xEE);
+
+			// pick by low_idx
+			low_val = __lasx_xvshuf_b(low_elem, low_elem, low_idx);
+
+			// pick by high_idx
+			high_val = __lasx_xvshuf_b(high_elem, high_elem, high_idx);
+
+			// accumulation on GF(2^8)
+			res4 = __lasx_xvxor_v(res4, __lasx_xvxor_v(low_val, high_val));
+
+			/* =================== for row 4 =================== */
+			// fetch one element from gftbls, which is 32 bytes
+			low_elem = __lasx_xvldx(gftbls, col_offset + (skip2 << 1));
+			high_elem = low_elem;
+
+			// duplicate low part
+			low_elem = __lasx_xvpermi_d(low_elem, 0x44);
+
+			// duplicate high part
+			high_elem = __lasx_xvpermi_d(high_elem, 0xEE);
+
+			// pick by low_idx
+			low_val = __lasx_xvshuf_b(low_elem, low_elem, low_idx);
+
+			// pick by high_idx
+			high_val = __lasx_xvshuf_b(high_elem, high_elem, high_idx);
+
+			// accumulation on GF(2^8)
+			res5 = __lasx_xvxor_v(res5, __lasx_xvxor_v(low_val, high_val));
+		}
+
+		__lasx_xvstx(res1, dest[0], buf_offset);
+		__lasx_xvstx(res2, dest[1], buf_offset);
+		__lasx_xvstx(res3, dest[2], buf_offset);
+		__lasx_xvstx(res4, dest[3], buf_offset);
+		__lasx_xvstx(res5, dest[4], buf_offset);
+	}
+
+	if (remain == 0)
+		return;
+
+	// handle remain bytes
+	i = block_count << 5;
+	while (remain >= 8) {
+		for (l = 0; l < 5; ++l) {
+			sul = 0;
+			for (j = 0; j < vlen; ++j) {
+				index = *(unsigned long *)&src[j][i];
+				pos = &gftbls[(j << 5) + l * skip1];
+
+				tmp = pos[index & 0xF] ^ pos[16 + ((index >> 4) & 0xF)];
+				index = index >> 8;
+				tmp |= (unsigned long)(pos[index & 0xF] ^ pos[16 + ((index >> 4) & 0xF)]) << 8;
+				index = index >> 8;
+				tmp |= (unsigned long)(pos[index & 0xF] ^ pos[16 + ((index >> 4) & 0xF)]) << 16;
+				index = index >> 8;
+				tmp |= (unsigned long)(pos[index & 0xF] ^ pos[16 + ((index >> 4) & 0xF)]) << 24;
+				index = index >> 8;
+				tmp |= (unsigned long)(pos[index & 0xF] ^ pos[16 + ((index >> 4) & 0xF)]) << 32;
+				index = index >> 8;
+				tmp |= (unsigned long)(pos[index & 0xF] ^ pos[16 + ((index >> 4) & 0xF)]) << 40;
+				index = index >> 8;
+				tmp |= (unsigned long)(pos[index & 0xF] ^ pos[16 + ((index >> 4) & 0xF)]) << 48;
+				index = index >> 8;
+				tmp |= (unsigned long)(pos[index & 0xF] ^ pos[16 + ((index >> 4) & 0xF)]) << 56;
+
+				sul ^= tmp;
+			}
+			*(unsigned long *)&dest[l][i] = sul;
+		}
+		i += sizeof(unsigned long);
+		remain -= sizeof(unsigned long);
+	}
+
+	if (remain == 0)
+		return;
+
+	buf_offset = i;
+	for (l = 0; l < 5; l++) {
+		for (i = buf_offset; i < len; i++) {
+			suc = 0;
+			for (j = 0; j < vlen; j++) {
+				sval = src[j][i];
+				pos = &gftbls[(j << 5) + l * skip1];
+				suc ^= pos[sval & 0xF] ^ pos[16 + (sval >> 4)];
+			}
+			dest[l][i] = suc;
+		}
+	}
+}

--- a/erasure_code/loongarch64/gf_5vect_dot_prod_lasx_test.c
+++ b/erasure_code/loongarch64/gf_5vect_dot_prod_lasx_test.c
@@ -1,0 +1,806 @@
+/**********************************************************************
+  Copyright(c) 2011-2015 Intel Corporation All rights reserved.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions
+  are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in
+      the documentation and/or other materials provided with the
+      distribution.
+    * Neither the name of Intel Corporation nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+**********************************************************************/
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>		// for memset, memcmp
+#include "erasure_code.h"
+#include "ec_loongarch64.h"
+#include "types.h"
+
+#ifndef FUNCTION_UNDER_TEST
+# define FUNCTION_UNDER_TEST gf_5vect_dot_prod_lasx
+#endif
+#ifndef TEST_MIN_SIZE
+# define TEST_MIN_SIZE  16
+#endif
+
+#define str(s) #s
+#define xstr(s) str(s)
+
+#define TEST_LEN (8192+31)
+#define TEST_SIZE (TEST_LEN/2)
+#define TEST_MEM  TEST_SIZE
+#define TEST_LOOPS 20000
+#define TEST_TYPE_STR ""
+
+#ifndef TEST_SOURCES
+# define TEST_SOURCES  16
+#endif
+#ifndef RANDOMS
+# define RANDOMS 20
+#endif
+
+#ifdef EC_ALIGNED_ADDR
+// Define power of 2 range to check ptr, len alignment
+# define PTR_ALIGN_CHK_B 0
+# define LEN_ALIGN_CHK_B 0	// 0 for aligned only
+#else
+// Define power of 2 range to check ptr, len alignment
+# define PTR_ALIGN_CHK_B 32
+# define LEN_ALIGN_CHK_B 32	// 0 for aligned only
+#endif
+
+typedef unsigned char u8;
+
+void dump(unsigned char *buf, int len)
+{
+	int i;
+	for (i = 0; i < len;) {
+		printf(" %2x", 0xff & buf[i++]);
+		if (i % 32 == 0)
+			printf("\n");
+	}
+	printf("\n");
+}
+
+void dump_matrix(unsigned char **s, int k, int m)
+{
+	int i, j;
+	for (i = 0; i < k; i++) {
+		for (j = 0; j < m; j++) {
+			printf(" %2x", s[i][j]);
+		}
+		printf("\n");
+	}
+	printf("\n");
+}
+
+void dump_u8xu8(unsigned char *s, int k, int m)
+{
+	int i, j;
+	for (i = 0; i < k; i++) {
+		for (j = 0; j < m; j++) {
+			printf(" %2x", 0xff & s[j + (i * m)]);
+		}
+		printf("\n");
+	}
+	printf("\n");
+}
+
+int main(int argc, char *argv[])
+{
+	int i, j, rtest, srcs;
+	void *buf;
+	u8 g1[TEST_SOURCES], g2[TEST_SOURCES], g3[TEST_SOURCES];
+	u8 g4[TEST_SOURCES], g5[TEST_SOURCES], *g_tbls;
+	u8 *dest1, *dest2, *dest3, *dest4, *dest5, *buffs[TEST_SOURCES];
+	u8 *dest_ref1, *dest_ref2, *dest_ref3, *dest_ref4, *dest_ref5;
+	u8 *dest_ptrs[5];
+
+	int align, size;
+	unsigned char *efence_buffs[TEST_SOURCES];
+	unsigned int offset;
+	u8 *ubuffs[TEST_SOURCES];
+	u8 *udest_ptrs[5];
+	printf(xstr(FUNCTION_UNDER_TEST) ": %dx%d ", TEST_SOURCES, TEST_LEN);
+
+	// Allocate the arrays
+	for (i = 0; i < TEST_SOURCES; i++) {
+		if (posix_memalign(&buf, 64, TEST_LEN)) {
+			printf("alloc error: Fail");
+			return -1;
+		}
+		buffs[i] = buf;
+	}
+
+	if (posix_memalign(&buf, 16, 2 * (6 * TEST_SOURCES * 32))) {
+		printf("alloc error: Fail");
+		return -1;
+	}
+	g_tbls = buf;
+
+	if (posix_memalign(&buf, 64, TEST_LEN)) {
+		printf("alloc error: Fail");
+		return -1;
+	}
+	dest1 = buf;
+
+	if (posix_memalign(&buf, 64, TEST_LEN)) {
+		printf("alloc error: Fail");
+		return -1;
+	}
+	dest2 = buf;
+
+	if (posix_memalign(&buf, 64, TEST_LEN)) {
+		printf("alloc error: Fail");
+		return -1;
+	}
+	dest3 = buf;
+
+	if (posix_memalign(&buf, 64, TEST_LEN)) {
+		printf("alloc error: Fail");
+		return -1;
+	}
+	dest4 = buf;
+
+	if (posix_memalign(&buf, 64, TEST_LEN)) {
+		printf("alloc error: Fail");
+		return -1;
+	}
+	dest5 = buf;
+
+	if (posix_memalign(&buf, 64, TEST_LEN)) {
+		printf("alloc error: Fail");
+		return -1;
+	}
+	dest_ref1 = buf;
+
+	if (posix_memalign(&buf, 64, TEST_LEN)) {
+		printf("alloc error: Fail");
+		return -1;
+	}
+	dest_ref2 = buf;
+
+	if (posix_memalign(&buf, 64, TEST_LEN)) {
+		printf("alloc error: Fail");
+		return -1;
+	}
+	dest_ref3 = buf;
+
+	if (posix_memalign(&buf, 64, TEST_LEN)) {
+		printf("alloc error: Fail");
+		return -1;
+	}
+	dest_ref4 = buf;
+
+	if (posix_memalign(&buf, 64, TEST_LEN)) {
+		printf("alloc error: Fail");
+		return -1;
+	}
+	dest_ref5 = buf;
+
+	dest_ptrs[0] = dest1;
+	dest_ptrs[1] = dest2;
+	dest_ptrs[2] = dest3;
+	dest_ptrs[3] = dest4;
+	dest_ptrs[4] = dest5;
+
+	// Test of all zeros
+	for (i = 0; i < TEST_SOURCES; i++)
+		memset(buffs[i], 0, TEST_LEN);
+
+	memset(dest1, 0, TEST_LEN);
+	memset(dest2, 0, TEST_LEN);
+	memset(dest3, 0, TEST_LEN);
+	memset(dest4, 0, TEST_LEN);
+	memset(dest5, 0, TEST_LEN);
+	memset(dest_ref1, 0, TEST_LEN);
+	memset(dest_ref2, 0, TEST_LEN);
+	memset(dest_ref3, 0, TEST_LEN);
+	memset(dest_ref4, 0, TEST_LEN);
+	memset(dest_ref5, 0, TEST_LEN);
+	memset(g1, 2, TEST_SOURCES);
+	memset(g2, 1, TEST_SOURCES);
+	memset(g3, 7, TEST_SOURCES);
+	memset(g4, 9, TEST_SOURCES);
+	memset(g5, 4, TEST_SOURCES);
+
+	for (i = 0; i < TEST_SOURCES; i++) {
+		gf_vect_mul_init(g1[i], &g_tbls[i * 32]);
+		gf_vect_mul_init(g2[i], &g_tbls[32 * TEST_SOURCES + i * 32]);
+		gf_vect_mul_init(g3[i], &g_tbls[64 * TEST_SOURCES + i * 32]);
+		gf_vect_mul_init(g4[i], &g_tbls[96 * TEST_SOURCES + i * 32]);
+		gf_vect_mul_init(g5[i], &g_tbls[128 * TEST_SOURCES + i * 32]);
+	}
+
+	gf_vect_dot_prod_base(TEST_LEN, TEST_SOURCES, &g_tbls[0], buffs, dest_ref1);
+	gf_vect_dot_prod_base(TEST_LEN, TEST_SOURCES, &g_tbls[32 * TEST_SOURCES], buffs,
+			      dest_ref2);
+	gf_vect_dot_prod_base(TEST_LEN, TEST_SOURCES, &g_tbls[64 * TEST_SOURCES], buffs,
+			      dest_ref3);
+	gf_vect_dot_prod_base(TEST_LEN, TEST_SOURCES, &g_tbls[96 * TEST_SOURCES], buffs,
+			      dest_ref4);
+	gf_vect_dot_prod_base(TEST_LEN, TEST_SOURCES, &g_tbls[128 * TEST_SOURCES], buffs,
+			      dest_ref5);
+
+	FUNCTION_UNDER_TEST(TEST_LEN, TEST_SOURCES, g_tbls, buffs, dest_ptrs);
+
+	if (0 != memcmp(dest_ref1, dest1, TEST_LEN)) {
+		printf("Fail zero " xstr(FUNCTION_UNDER_TEST) " test1\n");
+		dump_matrix(buffs, 5, TEST_SOURCES);
+		printf("dprod_base:");
+		dump(dest_ref1, 25);
+		printf("dprod_dut:");
+		dump(dest1, 25);
+		return -1;
+	}
+	if (0 != memcmp(dest_ref2, dest2, TEST_LEN)) {
+		printf("Fail zero " xstr(FUNCTION_UNDER_TEST) " test2\n");
+		dump_matrix(buffs, 5, TEST_SOURCES);
+		printf("dprod_base:");
+		dump(dest_ref2, 25);
+		printf("dprod_dut:");
+		dump(dest2, 25);
+		return -1;
+	}
+	if (0 != memcmp(dest_ref3, dest3, TEST_LEN)) {
+		printf("Fail zero " xstr(FUNCTION_UNDER_TEST) " test3\n");
+		dump_matrix(buffs, 5, TEST_SOURCES);
+		printf("dprod_base:");
+		dump(dest_ref3, 25);
+		printf("dprod_dut:");
+		dump(dest3, 25);
+		return -1;
+	}
+	if (0 != memcmp(dest_ref4, dest4, TEST_LEN)) {
+		printf("Fail zero " xstr(FUNCTION_UNDER_TEST) " test4\n");
+		dump_matrix(buffs, 5, TEST_SOURCES);
+		printf("dprod_base:");
+		dump(dest_ref4, 25);
+		printf("dprod_dut:");
+		dump(dest4, 25);
+		return -1;
+	}
+	if (0 != memcmp(dest_ref5, dest5, TEST_LEN)) {
+		printf("Fail zero " xstr(FUNCTION_UNDER_TEST) " test5\n");
+		dump_matrix(buffs, 5, TEST_SOURCES);
+		printf("dprod_base:");
+		dump(dest_ref5, 25);
+		printf("dprod_dut:");
+		dump(dest5, 25);
+		return -1;
+	}
+	putchar('.');
+
+	// Rand data test
+
+	for (rtest = 0; rtest < RANDOMS; rtest++) {
+		for (i = 0; i < TEST_SOURCES; i++)
+			for (j = 0; j < TEST_LEN; j++)
+				buffs[i][j] = rand();
+
+		for (i = 0; i < TEST_SOURCES; i++) {
+			g1[i] = rand();
+			g2[i] = rand();
+			g3[i] = rand();
+			g4[i] = rand();
+			g5[i] = rand();
+		}
+
+		for (i = 0; i < TEST_SOURCES; i++) {
+			gf_vect_mul_init(g1[i], &g_tbls[i * 32]);
+			gf_vect_mul_init(g2[i], &g_tbls[(32 * TEST_SOURCES) + (i * 32)]);
+			gf_vect_mul_init(g3[i], &g_tbls[(64 * TEST_SOURCES) + (i * 32)]);
+			gf_vect_mul_init(g4[i], &g_tbls[(96 * TEST_SOURCES) + (i * 32)]);
+			gf_vect_mul_init(g5[i], &g_tbls[(128 * TEST_SOURCES) + (i * 32)]);
+		}
+
+		gf_vect_dot_prod_base(TEST_LEN, TEST_SOURCES, &g_tbls[0], buffs, dest_ref1);
+		gf_vect_dot_prod_base(TEST_LEN, TEST_SOURCES, &g_tbls[32 * TEST_SOURCES],
+				      buffs, dest_ref2);
+		gf_vect_dot_prod_base(TEST_LEN, TEST_SOURCES, &g_tbls[64 * TEST_SOURCES],
+				      buffs, dest_ref3);
+		gf_vect_dot_prod_base(TEST_LEN, TEST_SOURCES, &g_tbls[96 * TEST_SOURCES],
+				      buffs, dest_ref4);
+		gf_vect_dot_prod_base(TEST_LEN, TEST_SOURCES, &g_tbls[128 * TEST_SOURCES],
+				      buffs, dest_ref5);
+
+		FUNCTION_UNDER_TEST(TEST_LEN, TEST_SOURCES, g_tbls, buffs, dest_ptrs);
+
+		if (0 != memcmp(dest_ref1, dest1, TEST_LEN)) {
+			printf("Fail rand " xstr(FUNCTION_UNDER_TEST) " test1 %d\n", rtest);
+			dump_matrix(buffs, 5, TEST_SOURCES);
+			printf("dprod_base:");
+			dump(dest_ref1, 25);
+			printf("dprod_dut:");
+			dump(dest1, 25);
+			return -1;
+		}
+		if (0 != memcmp(dest_ref2, dest2, TEST_LEN)) {
+			printf("Fail rand " xstr(FUNCTION_UNDER_TEST) " test2 %d\n", rtest);
+			dump_matrix(buffs, 5, TEST_SOURCES);
+			printf("dprod_base:");
+			dump(dest_ref2, 25);
+			printf("dprod_dut:");
+			dump(dest2, 25);
+			return -1;
+		}
+		if (0 != memcmp(dest_ref3, dest3, TEST_LEN)) {
+			printf("Fail rand " xstr(FUNCTION_UNDER_TEST) " test3 %d\n", rtest);
+			dump_matrix(buffs, 5, TEST_SOURCES);
+			printf("dprod_base:");
+			dump(dest_ref3, 25);
+			printf("dprod_dut:");
+			dump(dest3, 25);
+			return -1;
+		}
+		if (0 != memcmp(dest_ref4, dest4, TEST_LEN)) {
+			printf("Fail rand " xstr(FUNCTION_UNDER_TEST) " test4 %d\n", rtest);
+			dump_matrix(buffs, 5, TEST_SOURCES);
+			printf("dprod_base:");
+			dump(dest_ref4, 25);
+			printf("dprod_dut:");
+			dump(dest4, 25);
+			return -1;
+		}
+		if (0 != memcmp(dest_ref5, dest5, TEST_LEN)) {
+			printf("Fail rand " xstr(FUNCTION_UNDER_TEST) " test5 %d\n", rtest);
+			dump_matrix(buffs, 5, TEST_SOURCES);
+			printf("dprod_base:");
+			dump(dest_ref5, 25);
+			printf("dprod_dut:");
+			dump(dest5, 25);
+			return -1;
+		}
+
+		putchar('.');
+	}
+
+	// Rand data test with varied parameters
+	for (rtest = 0; rtest < RANDOMS; rtest++) {
+		for (srcs = TEST_SOURCES; srcs > 0; srcs--) {
+			for (i = 0; i < srcs; i++)
+				for (j = 0; j < TEST_LEN; j++)
+					buffs[i][j] = rand();
+
+			for (i = 0; i < srcs; i++) {
+				g1[i] = rand();
+				g2[i] = rand();
+				g3[i] = rand();
+				g4[i] = rand();
+				g5[i] = rand();
+			}
+
+			for (i = 0; i < srcs; i++) {
+				gf_vect_mul_init(g1[i], &g_tbls[i * 32]);
+				gf_vect_mul_init(g2[i], &g_tbls[(32 * srcs) + (i * 32)]);
+				gf_vect_mul_init(g3[i], &g_tbls[(64 * srcs) + (i * 32)]);
+				gf_vect_mul_init(g4[i], &g_tbls[(96 * srcs) + (i * 32)]);
+				gf_vect_mul_init(g5[i], &g_tbls[(128 * srcs) + (i * 32)]);
+			}
+
+			gf_vect_dot_prod_base(TEST_LEN, srcs, &g_tbls[0], buffs, dest_ref1);
+			gf_vect_dot_prod_base(TEST_LEN, srcs, &g_tbls[32 * srcs], buffs,
+					      dest_ref2);
+			gf_vect_dot_prod_base(TEST_LEN, srcs, &g_tbls[64 * srcs], buffs,
+					      dest_ref3);
+			gf_vect_dot_prod_base(TEST_LEN, srcs, &g_tbls[96 * srcs], buffs,
+					      dest_ref4);
+			gf_vect_dot_prod_base(TEST_LEN, srcs, &g_tbls[128 * srcs], buffs,
+					      dest_ref5);
+
+			FUNCTION_UNDER_TEST(TEST_LEN, srcs, g_tbls, buffs, dest_ptrs);
+
+			if (0 != memcmp(dest_ref1, dest1, TEST_LEN)) {
+				printf("Fail rand " xstr(FUNCTION_UNDER_TEST)
+				       " test1 srcs=%d\n", srcs);
+				dump_matrix(buffs, 5, TEST_SOURCES);
+				printf("dprod_base:");
+				dump(dest_ref1, 25);
+				printf("dprod_dut:");
+				dump(dest1, 25);
+				return -1;
+			}
+			if (0 != memcmp(dest_ref2, dest2, TEST_LEN)) {
+				printf("Fail rand " xstr(FUNCTION_UNDER_TEST)
+				       " test2 srcs=%d\n", srcs);
+				dump_matrix(buffs, 5, TEST_SOURCES);
+				printf("dprod_base:");
+				dump(dest_ref2, 25);
+				printf("dprod_dut:");
+				dump(dest2, 25);
+				return -1;
+			}
+			if (0 != memcmp(dest_ref3, dest3, TEST_LEN)) {
+				printf("Fail rand " xstr(FUNCTION_UNDER_TEST)
+				       " test3 srcs=%d\n", srcs);
+				dump_matrix(buffs, 5, TEST_SOURCES);
+				printf("dprod_base:");
+				dump(dest_ref3, 25);
+				printf("dprod_dut:");
+				dump(dest3, 25);
+				return -1;
+			}
+			if (0 != memcmp(dest_ref4, dest4, TEST_LEN)) {
+				printf("Fail rand " xstr(FUNCTION_UNDER_TEST)
+				       " test4 srcs=%d\n", srcs);
+				dump_matrix(buffs, 5, TEST_SOURCES);
+				printf("dprod_base:");
+				dump(dest_ref4, 25);
+				printf("dprod_dut:");
+				dump(dest4, 25);
+				return -1;
+			}
+			if (0 != memcmp(dest_ref5, dest5, TEST_LEN)) {
+				printf("Fail rand " xstr(FUNCTION_UNDER_TEST)
+				       " test5 srcs=%d\n", srcs);
+				dump_matrix(buffs, 5, TEST_SOURCES);
+				printf("dprod_base:");
+				dump(dest_ref5, 25);
+				printf("dprod_dut:");
+				dump(dest5, 25);
+				return -1;
+			}
+
+			putchar('.');
+		}
+	}
+
+	// Run tests at end of buffer for Electric Fence
+	align = (LEN_ALIGN_CHK_B != 0) ? 1 : 16;
+	for (size = TEST_MIN_SIZE; size <= TEST_SIZE; size += align) {
+		for (i = 0; i < TEST_SOURCES; i++)
+			for (j = 0; j < TEST_LEN; j++)
+				buffs[i][j] = rand();
+
+		for (i = 0; i < TEST_SOURCES; i++)	// Line up TEST_SIZE from end
+			efence_buffs[i] = buffs[i] + TEST_LEN - size;
+
+		for (i = 0; i < TEST_SOURCES; i++) {
+			g1[i] = rand();
+			g2[i] = rand();
+			g3[i] = rand();
+			g4[i] = rand();
+			g5[i] = rand();
+		}
+
+		for (i = 0; i < TEST_SOURCES; i++) {
+			gf_vect_mul_init(g1[i], &g_tbls[i * 32]);
+			gf_vect_mul_init(g2[i], &g_tbls[(32 * TEST_SOURCES) + (i * 32)]);
+			gf_vect_mul_init(g3[i], &g_tbls[(64 * TEST_SOURCES) + (i * 32)]);
+			gf_vect_mul_init(g4[i], &g_tbls[(96 * TEST_SOURCES) + (i * 32)]);
+			gf_vect_mul_init(g5[i], &g_tbls[(128 * TEST_SOURCES) + (i * 32)]);
+		}
+
+		gf_vect_dot_prod_base(size, TEST_SOURCES, &g_tbls[0], efence_buffs, dest_ref1);
+		gf_vect_dot_prod_base(size, TEST_SOURCES, &g_tbls[32 * TEST_SOURCES],
+				      efence_buffs, dest_ref2);
+		gf_vect_dot_prod_base(size, TEST_SOURCES, &g_tbls[64 * TEST_SOURCES],
+				      efence_buffs, dest_ref3);
+		gf_vect_dot_prod_base(size, TEST_SOURCES, &g_tbls[96 * TEST_SOURCES],
+				      efence_buffs, dest_ref4);
+		gf_vect_dot_prod_base(size, TEST_SOURCES, &g_tbls[128 * TEST_SOURCES],
+				      efence_buffs, dest_ref5);
+
+		FUNCTION_UNDER_TEST(size, TEST_SOURCES, g_tbls, efence_buffs, dest_ptrs);
+
+		if (0 != memcmp(dest_ref1, dest1, size)) {
+			printf("Fail rand " xstr(FUNCTION_UNDER_TEST) " test1 %d\n", rtest);
+			dump_matrix(efence_buffs, 5, TEST_SOURCES);
+			printf("dprod_base:");
+			dump(dest_ref1, align);
+			printf("dprod_dut:");
+			dump(dest1, align);
+			return -1;
+		}
+
+		if (0 != memcmp(dest_ref2, dest2, size)) {
+			printf("Fail rand " xstr(FUNCTION_UNDER_TEST) " test2 %d\n", rtest);
+			dump_matrix(efence_buffs, 5, TEST_SOURCES);
+			printf("dprod_base:");
+			dump(dest_ref2, align);
+			printf("dprod_dut:");
+			dump(dest2, align);
+			return -1;
+		}
+
+		if (0 != memcmp(dest_ref3, dest3, size)) {
+			printf("Fail rand " xstr(FUNCTION_UNDER_TEST) " test3 %d\n", rtest);
+			dump_matrix(efence_buffs, 5, TEST_SOURCES);
+			printf("dprod_base:");
+			dump(dest_ref3, align);
+			printf("dprod_dut:");
+			dump(dest3, align);
+			return -1;
+		}
+
+		if (0 != memcmp(dest_ref4, dest4, size)) {
+			printf("Fail rand " xstr(FUNCTION_UNDER_TEST) " test4 %d\n", rtest);
+			dump_matrix(efence_buffs, 5, TEST_SOURCES);
+			printf("dprod_base:");
+			dump(dest_ref4, align);
+			printf("dprod_dut:");
+			dump(dest4, align);
+			return -1;
+		}
+
+		if (0 != memcmp(dest_ref5, dest5, size)) {
+			printf("Fail rand " xstr(FUNCTION_UNDER_TEST) " test5 %d\n", rtest);
+			dump_matrix(efence_buffs, 5, TEST_SOURCES);
+			printf("dprod_base:");
+			dump(dest_ref5, align);
+			printf("dprod_dut:");
+			dump(dest5, align);
+			return -1;
+		}
+
+		putchar('.');
+	}
+
+	// Test rand ptr alignment if available
+
+	for (rtest = 0; rtest < RANDOMS; rtest++) {
+		size = (TEST_LEN - PTR_ALIGN_CHK_B) & ~(TEST_MIN_SIZE - 1);
+		srcs = rand() % TEST_SOURCES;
+		if (srcs == 0)
+			continue;
+
+		offset = (PTR_ALIGN_CHK_B != 0) ? 1 : PTR_ALIGN_CHK_B;
+		// Add random offsets
+		for (i = 0; i < srcs; i++)
+			ubuffs[i] = buffs[i] + (rand() & (PTR_ALIGN_CHK_B - offset));
+
+		udest_ptrs[0] = dest1 + (rand() & (PTR_ALIGN_CHK_B - offset));
+		udest_ptrs[1] = dest2 + (rand() & (PTR_ALIGN_CHK_B - offset));
+		udest_ptrs[2] = dest3 + (rand() & (PTR_ALIGN_CHK_B - offset));
+		udest_ptrs[3] = dest4 + (rand() & (PTR_ALIGN_CHK_B - offset));
+		udest_ptrs[4] = dest5 + (rand() & (PTR_ALIGN_CHK_B - offset));
+
+		memset(dest1, 0, TEST_LEN);	// zero pad to check write-over
+		memset(dest2, 0, TEST_LEN);
+		memset(dest3, 0, TEST_LEN);
+		memset(dest4, 0, TEST_LEN);
+		memset(dest5, 0, TEST_LEN);
+
+		for (i = 0; i < srcs; i++)
+			for (j = 0; j < size; j++)
+				ubuffs[i][j] = rand();
+
+		for (i = 0; i < srcs; i++) {
+			g1[i] = rand();
+			g2[i] = rand();
+			g3[i] = rand();
+			g4[i] = rand();
+			g5[i] = rand();
+		}
+
+		for (i = 0; i < srcs; i++) {
+			gf_vect_mul_init(g1[i], &g_tbls[i * 32]);
+			gf_vect_mul_init(g2[i], &g_tbls[(32 * srcs) + (i * 32)]);
+			gf_vect_mul_init(g3[i], &g_tbls[(64 * srcs) + (i * 32)]);
+			gf_vect_mul_init(g4[i], &g_tbls[(96 * srcs) + (i * 32)]);
+			gf_vect_mul_init(g5[i], &g_tbls[(128 * srcs) + (i * 32)]);
+		}
+
+		gf_vect_dot_prod_base(size, srcs, &g_tbls[0], ubuffs, dest_ref1);
+		gf_vect_dot_prod_base(size, srcs, &g_tbls[32 * srcs], ubuffs, dest_ref2);
+		gf_vect_dot_prod_base(size, srcs, &g_tbls[64 * srcs], ubuffs, dest_ref3);
+		gf_vect_dot_prod_base(size, srcs, &g_tbls[96 * srcs], ubuffs, dest_ref4);
+		gf_vect_dot_prod_base(size, srcs, &g_tbls[128 * srcs], ubuffs, dest_ref5);
+
+		FUNCTION_UNDER_TEST(size, srcs, g_tbls, ubuffs, udest_ptrs);
+
+		if (memcmp(dest_ref1, udest_ptrs[0], size)) {
+			printf("Fail rand " xstr(FUNCTION_UNDER_TEST) " test ualign srcs=%d\n",
+			       srcs);
+			dump_matrix(ubuffs, 5, TEST_SOURCES);
+			printf("dprod_base:");
+			dump(dest_ref1, 25);
+			printf("dprod_dut:");
+			dump(udest_ptrs[0], 25);
+			return -1;
+		}
+		if (memcmp(dest_ref2, udest_ptrs[1], size)) {
+			printf("Fail rand " xstr(FUNCTION_UNDER_TEST) " test ualign srcs=%d\n",
+			       srcs);
+			dump_matrix(ubuffs, 5, TEST_SOURCES);
+			printf("dprod_base:");
+			dump(dest_ref2, 25);
+			printf("dprod_dut:");
+			dump(udest_ptrs[1], 25);
+			return -1;
+		}
+		if (memcmp(dest_ref3, udest_ptrs[2], size)) {
+			printf("Fail rand " xstr(FUNCTION_UNDER_TEST) " test ualign srcs=%d\n",
+			       srcs);
+			dump_matrix(ubuffs, 5, TEST_SOURCES);
+			printf("dprod_base:");
+			dump(dest_ref3, 25);
+			printf("dprod_dut:");
+			dump(udest_ptrs[2], 25);
+			return -1;
+		}
+		if (memcmp(dest_ref4, udest_ptrs[3], size)) {
+			printf("Fail rand " xstr(FUNCTION_UNDER_TEST) " test ualign srcs=%d\n",
+			       srcs);
+			dump_matrix(ubuffs, 5, TEST_SOURCES);
+			printf("dprod_base:");
+			dump(dest_ref4, 25);
+			printf("dprod_dut:");
+			dump(udest_ptrs[3], 25);
+			return -1;
+		}
+		if (memcmp(dest_ref5, udest_ptrs[4], size)) {
+			printf("Fail rand " xstr(FUNCTION_UNDER_TEST) " test ualign srcs=%d\n",
+			       srcs);
+			dump_matrix(ubuffs, 5, TEST_SOURCES);
+			printf("dprod_base:");
+			dump(dest_ref5, 25);
+			printf("dprod_dut:");
+			dump(udest_ptrs[4], 25);
+			return -1;
+		}
+		// Confirm that padding around dests is unchanged
+		memset(dest_ref1, 0, PTR_ALIGN_CHK_B);	// Make reference zero buff
+		offset = udest_ptrs[0] - dest1;
+
+		if (memcmp(dest1, dest_ref1, offset)) {
+			printf("Fail rand ualign pad1 start\n");
+			return -1;
+		}
+		if (memcmp(dest1 + offset + size, dest_ref1, PTR_ALIGN_CHK_B - offset)) {
+			printf("Fail rand ualign pad1 end\n");
+			return -1;
+		}
+
+		offset = udest_ptrs[1] - dest2;
+		if (memcmp(dest2, dest_ref1, offset)) {
+			printf("Fail rand ualign pad2 start\n");
+			return -1;
+		}
+		if (memcmp(dest2 + offset + size, dest_ref1, PTR_ALIGN_CHK_B - offset)) {
+			printf("Fail rand ualign pad2 end\n");
+			return -1;
+		}
+
+		offset = udest_ptrs[2] - dest3;
+		if (memcmp(dest3, dest_ref1, offset)) {
+			printf("Fail rand ualign pad3 start\n");
+			return -1;
+		}
+		if (memcmp(dest3 + offset + size, dest_ref1, PTR_ALIGN_CHK_B - offset)) {
+			printf("Fail rand ualign pad3 end\n");
+			return -1;
+		}
+
+		offset = udest_ptrs[3] - dest4;
+		if (memcmp(dest4, dest_ref1, offset)) {
+			printf("Fail rand ualign pad4 start\n");
+			return -1;
+		}
+		if (memcmp(dest4 + offset + size, dest_ref1, PTR_ALIGN_CHK_B - offset)) {
+			printf("Fail rand ualign pad4 end\n");
+			return -1;
+		}
+
+		offset = udest_ptrs[4] - dest5;
+		if (memcmp(dest5, dest_ref1, offset)) {
+			printf("Fail rand ualign pad5 start\n");
+			return -1;
+		}
+		if (memcmp(dest5 + offset + size, dest_ref1, PTR_ALIGN_CHK_B - offset)) {
+			printf("Fail rand ualign pad5 end\n");
+			return -1;
+		}
+
+		putchar('.');
+	}
+
+	// Test all size alignment
+	align = (LEN_ALIGN_CHK_B != 0) ? 1 : 16;
+
+	for (size = TEST_LEN; size >= TEST_MIN_SIZE; size -= align) {
+		srcs = TEST_SOURCES;
+
+		for (i = 0; i < srcs; i++)
+			for (j = 0; j < size; j++)
+				buffs[i][j] = rand();
+
+		for (i = 0; i < srcs; i++) {
+			g1[i] = rand();
+			g2[i] = rand();
+			g3[i] = rand();
+			g4[i] = rand();
+			g5[i] = rand();
+		}
+
+		for (i = 0; i < srcs; i++) {
+			gf_vect_mul_init(g1[i], &g_tbls[i * 32]);
+			gf_vect_mul_init(g2[i], &g_tbls[(32 * srcs) + (i * 32)]);
+			gf_vect_mul_init(g3[i], &g_tbls[(64 * srcs) + (i * 32)]);
+			gf_vect_mul_init(g4[i], &g_tbls[(96 * srcs) + (i * 32)]);
+			gf_vect_mul_init(g5[i], &g_tbls[(128 * srcs) + (i * 32)]);
+		}
+
+		gf_vect_dot_prod_base(size, srcs, &g_tbls[0], buffs, dest_ref1);
+		gf_vect_dot_prod_base(size, srcs, &g_tbls[32 * srcs], buffs, dest_ref2);
+		gf_vect_dot_prod_base(size, srcs, &g_tbls[64 * srcs], buffs, dest_ref3);
+		gf_vect_dot_prod_base(size, srcs, &g_tbls[96 * srcs], buffs, dest_ref4);
+		gf_vect_dot_prod_base(size, srcs, &g_tbls[128 * srcs], buffs, dest_ref5);
+
+		FUNCTION_UNDER_TEST(size, srcs, g_tbls, buffs, dest_ptrs);
+
+		if (memcmp(dest_ref1, dest_ptrs[0], size)) {
+			printf("Fail rand " xstr(FUNCTION_UNDER_TEST) " test ualign len=%d\n",
+			       size);
+			dump_matrix(buffs, 5, TEST_SOURCES);
+			printf("dprod_base:");
+			dump(dest_ref1, 25);
+			printf("dprod_dut:");
+			dump(dest_ptrs[0], 25);
+
+			return -1;
+		}
+		if (memcmp(dest_ref2, dest_ptrs[1], size)) {
+			printf("Fail rand " xstr(FUNCTION_UNDER_TEST) " test ualign len=%d\n",
+			       size);
+			dump_matrix(buffs, 5, TEST_SOURCES);
+			printf("dprod_base:");
+			dump(dest_ref2, 25);
+			printf("dprod_dut:");
+			dump(dest_ptrs[1], 25);
+			return -1;
+		}
+		if (memcmp(dest_ref3, dest_ptrs[2], size)) {
+			printf("Fail rand " xstr(FUNCTION_UNDER_TEST) " test ualign len=%d\n",
+			       size);
+			dump_matrix(buffs, 5, TEST_SOURCES);
+			printf("dprod_base:");
+			dump(dest_ref3, 25);
+			printf("dprod_dut:");
+			dump(dest_ptrs[2], 25);
+			return -1;
+		}
+		if (memcmp(dest_ref4, dest_ptrs[3], size)) {
+			printf("Fail rand " xstr(FUNCTION_UNDER_TEST) " test ualign len=%d\n",
+			       size);
+			dump_matrix(buffs, 5, TEST_SOURCES);
+			printf("dprod_base:");
+			dump(dest_ref4, 25);
+			printf("dprod_dut:");
+			dump(dest_ptrs[3], 25);
+			return -1;
+		}
+		if (memcmp(dest_ref5, dest_ptrs[4], size)) {
+			printf("Fail rand " xstr(FUNCTION_UNDER_TEST) " test ualign len=%d\n",
+			       size);
+			dump_matrix(buffs, 5, TEST_SOURCES);
+			printf("dprod_base:");
+			dump(dest_ref5, 25);
+			printf("dprod_dut:");
+			dump(dest_ptrs[4], 25);
+			return -1;
+		}
+	}
+
+	printf("Pass\n");
+	return 0;
+
+}

--- a/erasure_code/loongarch64/gf_5vect_mad_lasx.c
+++ b/erasure_code/loongarch64/gf_5vect_mad_lasx.c
@@ -1,0 +1,243 @@
+/**********************************************************************
+  Copyright(c) 2022 Loongson Tech All rights reserved.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions
+  are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in
+      the documentation and/or other materials provided with the
+      distribution.
+    * Neither the name of Intel Corporation nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+**********************************************************************/
+
+#include <lasxintrin.h>
+
+void gf_5vect_mad_lasx(int len, int vec, int vec_i, unsigned char *gftbls,
+		       unsigned char *src, unsigned char **dest)
+{
+	int i, l;
+	int skip1 = vec << 5;
+	int skip2 = skip1 << 1;
+	int skip3 = skip1 + skip2;
+
+	int block_count = len >> 5;
+	int remain = len - (block_count << 5);
+	int buf_offset = 0, col_offset = vec_i << 5;
+
+	__m256i block, high_idx, low_idx;
+	__m256i high_elem, low_elem;
+       	__m256i	high_val, low_val;
+	__m256i res;
+
+	unsigned long index, tmp, tmp1;
+	unsigned char *pos;
+	unsigned char sval;
+
+	for (i = 0; i < block_count; ++i) {
+		/* read one block from src to update five rows */
+
+		buf_offset = i << 5;
+		// fetch one block from one buf into a vector variable,
+		// the block size is 32 bytes
+		block = __lasx_xvldx(src, buf_offset);
+
+		// get low indexes
+		low_idx = __lasx_xvandi_b(block, 0x0F);
+
+		// get high indexes: shift right 4 bits and add 0x10,
+		// which can index {0x10, ..., 0x1F}
+		high_idx = __lasx_xvori_b(__lasx_xvsrli_b(block, 4), 0x10);
+
+		/* =================== for row 0 =================== */
+		// fetch one element from gftbls, which is 32 bytes
+		low_elem = __lasx_xvldx(gftbls, col_offset);
+		high_elem = low_elem;
+
+		// duplicate low part
+		low_elem = __lasx_xvpermi_d(low_elem, 0x44);
+
+		// duplicate high part
+		high_elem = __lasx_xvpermi_d(high_elem, 0xEE);
+
+		// pick by low_idx
+		low_val = __lasx_xvshuf_b(low_elem, low_elem, low_idx);
+
+		// pick by high_idx
+		high_val = __lasx_xvshuf_b(high_elem, high_elem, high_idx);
+
+		// load old data
+		res = __lasx_xvldx(dest[0], buf_offset);
+
+		// accumulation on GF(2^8)
+		res = __lasx_xvxor_v(res, __lasx_xvxor_v(low_val, high_val));
+
+		// store new data
+		__lasx_xvstx(res, dest[0], buf_offset);
+
+		/* =================== for row 1 =================== */
+		// fetch one element from gftbls, which is 32 bytes
+		low_elem = __lasx_xvldx(gftbls, col_offset + skip1);
+		high_elem = low_elem;
+
+		// duplicate low part
+		low_elem = __lasx_xvpermi_d(low_elem, 0x44);
+
+		// duplicate high part
+		high_elem = __lasx_xvpermi_d(high_elem, 0xEE);
+
+		// pick by low_idx
+		low_val = __lasx_xvshuf_b(low_elem, low_elem, low_idx);
+
+		// pick by high_idx
+		high_val = __lasx_xvshuf_b(high_elem, high_elem, high_idx);
+
+		// load old data
+		res = __lasx_xvldx(dest[1], buf_offset);
+
+		// accumulation on GF(2^8)
+		res = __lasx_xvxor_v(res, __lasx_xvxor_v(low_val, high_val));
+
+		// store new data
+		__lasx_xvstx(res, dest[1], buf_offset);
+
+		/* =================== for row 2 =================== */
+		// fetch one element from gftbls, which is 32 bytes
+		low_elem = __lasx_xvldx(gftbls, col_offset + skip2);
+		high_elem = low_elem;
+
+		// duplicate low part
+		low_elem = __lasx_xvpermi_d(low_elem, 0x44);
+
+		// duplicate high part
+		high_elem = __lasx_xvpermi_d(high_elem, 0xEE);
+
+		// pick by low_idx
+		low_val = __lasx_xvshuf_b(low_elem, low_elem, low_idx);
+
+		// pick by high_idx
+		high_val = __lasx_xvshuf_b(high_elem, high_elem, high_idx);
+
+		// load old data
+		res = __lasx_xvldx(dest[2], buf_offset);
+
+		// accumulation on GF(2^8)
+		res = __lasx_xvxor_v(res, __lasx_xvxor_v(low_val, high_val));
+
+		// store new data
+		__lasx_xvstx(res, dest[2], buf_offset);
+
+		/* =================== for row 3 =================== */
+		// fetch one element from gftbls, which is 32 bytes
+		low_elem = __lasx_xvldx(gftbls, col_offset + skip3);
+		high_elem = low_elem;
+
+		// duplicate low part
+		low_elem = __lasx_xvpermi_d(low_elem, 0x44);
+
+		// duplicate high part
+		high_elem = __lasx_xvpermi_d(high_elem, 0xEE);
+
+		// pick by low_idx
+		low_val = __lasx_xvshuf_b(low_elem, low_elem, low_idx);
+
+		// pick by high_idx
+		high_val = __lasx_xvshuf_b(high_elem, high_elem, high_idx);
+
+		// load old data
+		res = __lasx_xvldx(dest[3], buf_offset);
+
+		// accumulation on GF(2^8)
+		res = __lasx_xvxor_v(res, __lasx_xvxor_v(low_val, high_val));
+
+		// store new data
+		__lasx_xvstx(res, dest[3], buf_offset);
+
+		/* =================== for row 4 =================== */
+		// fetch one element from gftbls, which is 32 bytes
+		low_elem = __lasx_xvldx(gftbls, col_offset + (skip2 << 1));
+		high_elem = low_elem;
+
+		// duplicate low part
+		low_elem = __lasx_xvpermi_d(low_elem, 0x44);
+
+		// duplicate high part
+		high_elem = __lasx_xvpermi_d(high_elem, 0xEE);
+
+		// pick by low_idx
+		low_val = __lasx_xvshuf_b(low_elem, low_elem, low_idx);
+
+		// pick by high_idx
+		high_val = __lasx_xvshuf_b(high_elem, high_elem, high_idx);
+
+		// load old data
+		res = __lasx_xvldx(dest[4], buf_offset);
+
+		// accumulation on GF(2^8)
+		res = __lasx_xvxor_v(res, __lasx_xvxor_v(low_val, high_val));
+
+		// store new data
+		__lasx_xvstx(res, dest[4], buf_offset);
+	}
+
+	if (remain == 0)
+		return;
+
+	// handle remain bytes
+	i = block_count << 5;
+	while (remain >= 8) {
+		tmp1 = *(unsigned long *)&src[i];
+		for (l = 0; l < 5; ++l) {
+			index = tmp1;
+			pos = &gftbls[col_offset + l * skip1];
+
+			tmp = pos[index & 0xF] ^ pos[16 + ((index >> 4) & 0xF)];
+			index = index >> 8;
+			tmp |= (unsigned long)(pos[index & 0xF] ^ pos[16 + ((index >> 4) & 0xF)]) << 8;
+			index = index >> 8;
+			tmp |= (unsigned long)(pos[index & 0xF] ^ pos[16 + ((index >> 4) & 0xF)]) << 16;
+			index = index >> 8;
+			tmp |= (unsigned long)(pos[index & 0xF] ^ pos[16 + ((index >> 4) & 0xF)]) << 24;
+			index = index >> 8;
+			tmp |= (unsigned long)(pos[index & 0xF] ^ pos[16 + ((index >> 4) & 0xF)]) << 32;
+			index = index >> 8;
+			tmp |= (unsigned long)(pos[index & 0xF] ^ pos[16 + ((index >> 4) & 0xF)]) << 40;
+			index = index >> 8;
+			tmp |= (unsigned long)(pos[index & 0xF] ^ pos[16 + ((index >> 4) & 0xF)]) << 48;
+			index = index >> 8;
+			tmp |= (unsigned long)(pos[index & 0xF] ^ pos[16 + ((index >> 4) & 0xF)]) << 56;
+
+			*(unsigned long *)&dest[l][i] ^= tmp;
+		}
+		i += sizeof(unsigned long);
+		remain -= sizeof(unsigned long);
+	}
+
+	if (remain == 0)
+		return;
+
+	buf_offset = i;
+	for (l = 0; l < 5; l++) {
+		for (i = buf_offset; i < len; i++) {
+			sval = src[i];
+			pos = &gftbls[col_offset + l * skip1];
+			dest[l][i] ^= pos[sval & 0xF] ^ pos[16 + (sval >> 4)];
+		}
+	}
+}

--- a/erasure_code/loongarch64/gf_5vect_mad_lasx_test.c
+++ b/erasure_code/loongarch64/gf_5vect_mad_lasx_test.c
@@ -1,0 +1,519 @@
+/**********************************************************************
+  Copyright(c) 2011-2015 Intel Corporation All rights reserved.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions
+  are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in
+      the documentation and/or other materials provided with the
+      distribution.
+    * Neither the name of Intel Corporation nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+**********************************************************************/
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>		// for memset, memcmp
+#include "erasure_code.h"
+#include "types.h"
+
+#ifndef ALIGN_SIZE
+# define ALIGN_SIZE 32
+#endif
+
+#ifndef FUNCTION_UNDER_TEST
+//By default, test multi-binary version
+# define FUNCTION_UNDER_TEST gf_5vect_mad_lasx
+# define REF_FUNCTION gf_5vect_dot_prod_lasx
+# define VECT 5
+#endif
+
+#ifndef TEST_MIN_SIZE
+# define TEST_MIN_SIZE 64
+#endif
+
+#define str(s) #s
+#define xstr(s) str(s)
+
+#define TEST_LEN (8192+31)
+#define TEST_SIZE (TEST_LEN/2)
+#define TEST_MEM  TEST_SIZE
+#define TEST_LOOPS 20000
+#define TEST_TYPE_STR ""
+
+#ifndef TEST_SOURCES
+# define TEST_SOURCES  16
+#endif
+#ifndef RANDOMS
+# define RANDOMS 20
+#endif
+
+#ifdef EC_ALIGNED_ADDR
+// Define power of 2 range to check ptr, len alignment
+# define PTR_ALIGN_CHK_B 0
+# define LEN_ALIGN_CHK_B 0	// 0 for aligned only
+#else
+// Define power of 2 range to check ptr, len alignment
+# define PTR_ALIGN_CHK_B ALIGN_SIZE
+# define LEN_ALIGN_CHK_B ALIGN_SIZE	// 0 for aligned only
+#endif
+
+#define str(s) #s
+#define xstr(s) str(s)
+
+typedef unsigned char u8;
+
+#if (VECT == 1)
+# define LAST_ARG *dest
+#else
+# define LAST_ARG **dest
+#endif
+
+extern void FUNCTION_UNDER_TEST(int len, int vec, int vec_i, unsigned char *gftbls,
+				unsigned char *src, unsigned char LAST_ARG);
+extern void REF_FUNCTION(int len, int vlen, unsigned char *gftbls, unsigned char **src,
+			 unsigned char LAST_ARG);
+
+void dump(unsigned char *buf, int len)
+{
+	int i;
+	for (i = 0; i < len;) {
+		printf(" %2x", 0xff & buf[i++]);
+		if (i % 32 == 0)
+			printf("\n");
+	}
+	printf("\n");
+}
+
+void dump_matrix(unsigned char **s, int k, int m)
+{
+	int i, j;
+	for (i = 0; i < k; i++) {
+		for (j = 0; j < m; j++) {
+			printf(" %2x", s[i][j]);
+		}
+		printf("\n");
+	}
+	printf("\n");
+}
+
+void dump_u8xu8(unsigned char *s, int k, int m)
+{
+	int i, j;
+	for (i = 0; i < k; i++) {
+		for (j = 0; j < m; j++) {
+			printf(" %2x", 0xff & s[j + (i * m)]);
+		}
+		printf("\n");
+	}
+	printf("\n");
+}
+
+int main(int argc, char *argv[])
+{
+	int i, j, rtest, srcs;
+	void *buf;
+	u8 gf[6][TEST_SOURCES];
+	u8 *g_tbls;
+	u8 *dest_ref[VECT];
+	u8 *dest_ptrs[VECT], *buffs[TEST_SOURCES];
+	int vector = VECT;
+
+	int align, size;
+	unsigned char *efence_buffs[TEST_SOURCES];
+	unsigned int offset;
+	u8 *ubuffs[TEST_SOURCES];
+	u8 *udest_ptrs[VECT];
+	printf("test" xstr(FUNCTION_UNDER_TEST) ": %dx%d ", TEST_SOURCES, TEST_LEN);
+
+	// Allocate the arrays
+	for (i = 0; i < TEST_SOURCES; i++) {
+		if (posix_memalign(&buf, 64, TEST_LEN)) {
+			printf("alloc error: Fail");
+			return -1;
+		}
+		buffs[i] = buf;
+	}
+
+	if (posix_memalign(&buf, 16, 2 * (vector * TEST_SOURCES * 32))) {
+		printf("alloc error: Fail");
+		return -1;
+	}
+	g_tbls = buf;
+
+	for (i = 0; i < vector; i++) {
+		if (posix_memalign(&buf, 64, TEST_LEN)) {
+			printf("alloc error: Fail");
+			return -1;
+		}
+		dest_ptrs[i] = buf;
+		memset(dest_ptrs[i], 0, TEST_LEN);
+	}
+
+	for (i = 0; i < vector; i++) {
+		if (posix_memalign(&buf, 64, TEST_LEN)) {
+			printf("alloc error: Fail");
+			return -1;
+		}
+		dest_ref[i] = buf;
+		memset(dest_ref[i], 0, TEST_LEN);
+	}
+
+	// Test of all zeros
+	for (i = 0; i < TEST_SOURCES; i++)
+		memset(buffs[i], 0, TEST_LEN);
+
+	switch (vector) {
+	case 6:
+		memset(gf[5], 0xe6, TEST_SOURCES);
+	case 5:
+		memset(gf[4], 4, TEST_SOURCES);
+	case 4:
+		memset(gf[3], 9, TEST_SOURCES);
+	case 3:
+		memset(gf[2], 7, TEST_SOURCES);
+	case 2:
+		memset(gf[1], 1, TEST_SOURCES);
+	case 1:
+		memset(gf[0], 2, TEST_SOURCES);
+		break;
+	default:
+		return -1;
+	}
+
+	for (i = 0; i < TEST_SOURCES; i++)
+		for (j = 0; j < TEST_LEN; j++)
+			buffs[i][j] = rand();
+
+	for (i = 0; i < vector; i++)
+		for (j = 0; j < TEST_SOURCES; j++) {
+			gf[i][j] = rand();
+			gf_vect_mul_init(gf[i][j], &g_tbls[i * (32 * TEST_SOURCES) + j * 32]);
+		}
+
+	for (i = 0; i < vector; i++)
+		gf_vect_dot_prod_base(TEST_LEN, TEST_SOURCES, &g_tbls[i * 32 * TEST_SOURCES],
+				      buffs, dest_ref[i]);
+
+	for (i = 0; i < vector; i++)
+		memset(dest_ptrs[i], 0, TEST_LEN);
+	for (i = 0; i < TEST_SOURCES; i++) {
+#if (VECT == 1)
+		FUNCTION_UNDER_TEST(TEST_LEN, TEST_SOURCES, i, g_tbls, buffs[i], *dest_ptrs);
+#else
+		FUNCTION_UNDER_TEST(TEST_LEN, TEST_SOURCES, i, g_tbls, buffs[i], dest_ptrs);
+#endif
+	}
+	for (i = 0; i < vector; i++) {
+		if (0 != memcmp(dest_ref[i], dest_ptrs[i], TEST_LEN)) {
+			printf("Fail zero " xstr(FUNCTION_UNDER_TEST) " test%d\n", i);
+			dump_matrix(buffs, vector, TEST_SOURCES);
+			printf("dprod_base:");
+			dump(dest_ref[i], 25);
+			printf("dprod_dut:");
+			dump(dest_ptrs[i], 25);
+			return -1;
+		}
+	}
+
+#if (VECT == 1)
+	REF_FUNCTION(TEST_LEN, TEST_SOURCES, g_tbls, buffs, *dest_ref);
+#else
+	REF_FUNCTION(TEST_LEN, TEST_SOURCES, g_tbls, buffs, dest_ref);
+#endif
+	for (i = 0; i < vector; i++) {
+		if (0 != memcmp(dest_ref[i], dest_ptrs[i], TEST_LEN)) {
+			printf("Fail zero " xstr(FUNCTION_UNDER_TEST) " test%d\n", i);
+			dump_matrix(buffs, vector, TEST_SOURCES);
+			printf("dprod_base:");
+			dump(dest_ref[i], 25);
+			printf("dprod_dut:");
+			dump(dest_ptrs[i], 25);
+			return -1;
+		}
+	}
+
+	putchar('.');
+
+	// Rand data test
+
+	for (rtest = 0; rtest < RANDOMS; rtest++) {
+		for (i = 0; i < TEST_SOURCES; i++)
+			for (j = 0; j < TEST_LEN; j++)
+				buffs[i][j] = rand();
+
+		for (i = 0; i < vector; i++)
+			for (j = 0; j < TEST_SOURCES; j++) {
+				gf[i][j] = rand();
+				gf_vect_mul_init(gf[i][j],
+						 &g_tbls[i * (32 * TEST_SOURCES) + j * 32]);
+			}
+
+		for (i = 0; i < vector; i++)
+			gf_vect_dot_prod_base(TEST_LEN, TEST_SOURCES,
+					      &g_tbls[i * 32 * TEST_SOURCES], buffs,
+					      dest_ref[i]);
+
+		for (i = 0; i < vector; i++)
+			memset(dest_ptrs[i], 0, TEST_LEN);
+		for (i = 0; i < TEST_SOURCES; i++) {
+#if (VECT == 1)
+			FUNCTION_UNDER_TEST(TEST_LEN, TEST_SOURCES, i, g_tbls, buffs[i],
+					    *dest_ptrs);
+#else
+			FUNCTION_UNDER_TEST(TEST_LEN, TEST_SOURCES, i, g_tbls, buffs[i],
+					    dest_ptrs);
+#endif
+		}
+		for (i = 0; i < vector; i++) {
+			if (0 != memcmp(dest_ref[i], dest_ptrs[i], TEST_LEN)) {
+				printf("Fail rand " xstr(FUNCTION_UNDER_TEST) " test%d %d\n",
+				       i, rtest);
+				dump_matrix(buffs, vector, TEST_SOURCES);
+				printf("dprod_base:");
+				dump(dest_ref[i], 25);
+				printf("dprod_dut:");
+				dump(dest_ptrs[i], 25);
+				return -1;
+			}
+		}
+
+		putchar('.');
+	}
+
+	// Rand data test with varied parameters
+	for (rtest = 0; rtest < RANDOMS; rtest++) {
+		for (srcs = TEST_SOURCES; srcs > 0; srcs--) {
+			for (i = 0; i < srcs; i++)
+				for (j = 0; j < TEST_LEN; j++)
+					buffs[i][j] = rand();
+
+			for (i = 0; i < vector; i++)
+				for (j = 0; j < srcs; j++) {
+					gf[i][j] = rand();
+					gf_vect_mul_init(gf[i][j],
+							 &g_tbls[i * (32 * srcs) + j * 32]);
+				}
+
+			for (i = 0; i < vector; i++)
+				gf_vect_dot_prod_base(TEST_LEN, srcs, &g_tbls[i * 32 * srcs],
+						      buffs, dest_ref[i]);
+
+			for (i = 0; i < vector; i++)
+				memset(dest_ptrs[i], 0, TEST_LEN);
+			for (i = 0; i < srcs; i++) {
+#if (VECT == 1)
+				FUNCTION_UNDER_TEST(TEST_LEN, srcs, i, g_tbls, buffs[i],
+						    *dest_ptrs);
+#else
+				FUNCTION_UNDER_TEST(TEST_LEN, srcs, i, g_tbls, buffs[i],
+						    dest_ptrs);
+#endif
+
+			}
+			for (i = 0; i < vector; i++) {
+				if (0 != memcmp(dest_ref[i], dest_ptrs[i], TEST_LEN)) {
+					printf("Fail rand " xstr(FUNCTION_UNDER_TEST)
+					       " test%d srcs=%d\n", i, srcs);
+					dump_matrix(buffs, vector, TEST_SOURCES);
+					printf("dprod_base:");
+					dump(dest_ref[i], 25);
+					printf("dprod_dut:");
+					dump(dest_ptrs[i], 25);
+					return -1;
+				}
+			}
+
+			putchar('.');
+		}
+	}
+
+	// Run tests at end of buffer for Electric Fence
+	align = (LEN_ALIGN_CHK_B != 0) ? 1 : ALIGN_SIZE;
+	for (size = TEST_MIN_SIZE; size <= TEST_SIZE; size += align) {
+		for (i = 0; i < TEST_SOURCES; i++)
+			for (j = 0; j < TEST_LEN; j++)
+				buffs[i][j] = rand();
+
+		for (i = 0; i < TEST_SOURCES; i++)	// Line up TEST_SIZE from end
+			efence_buffs[i] = buffs[i] + TEST_LEN - size;
+
+		for (i = 0; i < vector; i++)
+			for (j = 0; j < TEST_SOURCES; j++) {
+				gf[i][j] = rand();
+				gf_vect_mul_init(gf[i][j],
+						 &g_tbls[i * (32 * TEST_SOURCES) + j * 32]);
+			}
+
+		for (i = 0; i < vector; i++)
+			gf_vect_dot_prod_base(size, TEST_SOURCES,
+					      &g_tbls[i * 32 * TEST_SOURCES], efence_buffs,
+					      dest_ref[i]);
+
+		for (i = 0; i < vector; i++)
+			memset(dest_ptrs[i], 0, size);
+		for (i = 0; i < TEST_SOURCES; i++) {
+#if (VECT == 1)
+			FUNCTION_UNDER_TEST(size, TEST_SOURCES, i, g_tbls, efence_buffs[i],
+					    *dest_ptrs);
+#else
+			FUNCTION_UNDER_TEST(size, TEST_SOURCES, i, g_tbls, efence_buffs[i],
+					    dest_ptrs);
+#endif
+		}
+		for (i = 0; i < vector; i++) {
+			if (0 != memcmp(dest_ref[i], dest_ptrs[i], size)) {
+				printf("Fail rand " xstr(FUNCTION_UNDER_TEST)
+				       " test%d size=%d\n", i, size);
+				dump_matrix(buffs, vector, TEST_SOURCES);
+				printf("dprod_base:");
+				dump(dest_ref[i], TEST_MIN_SIZE + align);
+				printf("dprod_dut:");
+				dump(dest_ptrs[i], TEST_MIN_SIZE + align);
+				return -1;
+			}
+		}
+
+		putchar('.');
+	}
+
+	// Test rand ptr alignment if available
+
+	for (rtest = 0; rtest < RANDOMS; rtest++) {
+		size = (TEST_LEN - PTR_ALIGN_CHK_B) & ~(TEST_MIN_SIZE - 1);
+		srcs = rand() % TEST_SOURCES;
+		if (srcs == 0)
+			continue;
+
+		offset = (PTR_ALIGN_CHK_B != 0) ? 1 : PTR_ALIGN_CHK_B;
+		// Add random offsets
+		for (i = 0; i < srcs; i++)
+			ubuffs[i] = buffs[i] + (rand() & (PTR_ALIGN_CHK_B - offset));
+
+		for (i = 0; i < vector; i++) {
+			udest_ptrs[i] = dest_ptrs[i] + (rand() & (PTR_ALIGN_CHK_B - offset));
+			memset(dest_ptrs[i], 0, TEST_LEN);	// zero pad to check write-over
+		}
+
+		for (i = 0; i < srcs; i++)
+			for (j = 0; j < size; j++)
+				ubuffs[i][j] = rand();
+
+		for (i = 0; i < vector; i++)
+			for (j = 0; j < srcs; j++) {
+				gf[i][j] = rand();
+				gf_vect_mul_init(gf[i][j], &g_tbls[i * (32 * srcs) + j * 32]);
+			}
+
+		for (i = 0; i < vector; i++)
+			gf_vect_dot_prod_base(size, srcs, &g_tbls[i * 32 * srcs], ubuffs,
+					      dest_ref[i]);
+
+		for (i = 0; i < srcs; i++) {
+#if (VECT == 1)
+			FUNCTION_UNDER_TEST(size, srcs, i, g_tbls, ubuffs[i], *udest_ptrs);
+#else
+			FUNCTION_UNDER_TEST(size, srcs, i, g_tbls, ubuffs[i], udest_ptrs);
+#endif
+		}
+		for (i = 0; i < vector; i++) {
+			if (0 != memcmp(dest_ref[i], udest_ptrs[i], size)) {
+				printf("Fail rand " xstr(FUNCTION_UNDER_TEST)
+				       " test%d ualign srcs=%d\n", i, srcs);
+				dump_matrix(buffs, vector, TEST_SOURCES);
+				printf("dprod_base:");
+				dump(dest_ref[i], 25);
+				printf("dprod_dut:");
+				dump(udest_ptrs[i], 25);
+				return -1;
+			}
+		}
+
+		// Confirm that padding around dests is unchanged
+		memset(dest_ref[0], 0, PTR_ALIGN_CHK_B);	// Make reference zero buff
+
+		for (i = 0; i < vector; i++) {
+			offset = udest_ptrs[i] - dest_ptrs[i];
+			if (memcmp(dest_ptrs[i], dest_ref[0], offset)) {
+				printf("Fail rand ualign pad1 start\n");
+				return -1;
+			}
+			if (memcmp
+			    (dest_ptrs[i] + offset + size, dest_ref[0],
+			     PTR_ALIGN_CHK_B - offset)) {
+				printf("Fail rand ualign pad1 end\n");
+				return -1;
+			}
+		}
+
+		putchar('.');
+	}
+
+	// Test all size alignment
+	align = (LEN_ALIGN_CHK_B != 0) ? 1 : ALIGN_SIZE;
+
+	for (size = TEST_LEN; size >= TEST_MIN_SIZE; size -= align) {
+		for (i = 0; i < TEST_SOURCES; i++)
+			for (j = 0; j < size; j++)
+				buffs[i][j] = rand();
+
+		for (i = 0; i < vector; i++) {
+			for (j = 0; j < TEST_SOURCES; j++) {
+				gf[i][j] = rand();
+				gf_vect_mul_init(gf[i][j],
+						 &g_tbls[i * (32 * TEST_SOURCES) + j * 32]);
+			}
+			memset(dest_ptrs[i], 0, TEST_LEN);	// zero pad to check write-over
+		}
+
+		for (i = 0; i < vector; i++)
+			gf_vect_dot_prod_base(size, TEST_SOURCES,
+					      &g_tbls[i * 32 * TEST_SOURCES], buffs,
+					      dest_ref[i]);
+
+		for (i = 0; i < TEST_SOURCES; i++) {
+#if (VECT == 1)
+			FUNCTION_UNDER_TEST(size, TEST_SOURCES, i, g_tbls, buffs[i],
+					    *dest_ptrs);
+#else
+			FUNCTION_UNDER_TEST(size, TEST_SOURCES, i, g_tbls, buffs[i],
+					    dest_ptrs);
+#endif
+		}
+		for (i = 0; i < vector; i++) {
+			if (0 != memcmp(dest_ref[i], dest_ptrs[i], size)) {
+				printf("Fail rand " xstr(FUNCTION_UNDER_TEST)
+				       " test%d ualign len=%d\n", i, size);
+				dump_matrix(buffs, vector, TEST_SOURCES);
+				printf("dprod_base:");
+				dump(dest_ref[i], 25);
+				printf("dprod_dut:");
+				dump(dest_ptrs[i], 25);
+				return -1;
+			}
+		}
+
+		putchar('.');
+
+	}
+
+	printf("Pass\n");
+	return 0;
+
+}

--- a/erasure_code/loongarch64/gf_6vect_dot_prod_lasx.c
+++ b/erasure_code/loongarch64/gf_6vect_dot_prod_lasx.c
@@ -1,0 +1,258 @@
+/**********************************************************************
+  Copyright(c) 2022 Loongson Tech All rights reserved.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions
+  are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in
+      the documentation and/or other materials provided with the
+      distribution.
+    * Neither the name of Intel Corporation nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+**********************************************************************/
+
+#include <lasxintrin.h>
+
+void gf_6vect_dot_prod_lasx(int len, int vlen, unsigned char *gftbls,
+			    unsigned char **src, unsigned char **dest)
+{
+	int i, j, l;
+	int skip1 = vlen << 5;
+	int skip2 = skip1 << 1;
+	int skip3 = skip1 + skip2;
+
+	int block_count = len >> 5;
+	int remain = len - (block_count << 5);
+	int buf_offset = 0, col_offset = 0;
+
+	__m256i block, high_idx, low_idx;
+	__m256i high_elem, low_elem;
+       	__m256i	high_val, low_val;
+	__m256i res1, res2, res3, res4, res5, res6;
+
+	unsigned long sul, index, tmp;
+	unsigned char *pos;
+	unsigned char suc, sval;
+
+	for (i = 0; i < block_count; ++i) {
+		res1 = __lasx_xvldi(0);
+		res2 = __lasx_xvldi(0);
+		res3 = __lasx_xvldi(0);
+		res4 = __lasx_xvldi(0);
+		res5 = __lasx_xvldi(0);
+		res6 = __lasx_xvldi(0);
+
+		buf_offset = i << 5;
+		for (j = 0; j < vlen; ++j) {
+			/* read one block from one buf to update six rows */
+
+			col_offset = j << 5;
+
+			// fetch one block from one buf into a vector variable,
+			// the block size is 32 bytes
+			block = __lasx_xvldx(src[j], buf_offset);
+
+			// get low indexes
+			low_idx = __lasx_xvandi_b(block, 0x0F);
+
+			// get high indexes: shift right 4 bits and add 0x10,
+			// which can index {0x10, ..., 0x1F}
+			high_idx = __lasx_xvori_b(__lasx_xvsrli_b(block, 4), 0x10);
+
+			/* =================== for row 0 =================== */
+			// fetch one element from gftbls, which is 32 bytes
+			low_elem = __lasx_xvldx(gftbls, col_offset);
+			high_elem = low_elem;
+
+			// duplicate low part
+			low_elem = __lasx_xvpermi_d(low_elem, 0x44);
+
+			// duplicate high part
+			high_elem = __lasx_xvpermi_d(high_elem, 0xEE);
+
+			// pick by low_idx
+			low_val = __lasx_xvshuf_b(low_elem, low_elem, low_idx);
+
+			// pick by high_idx
+			high_val = __lasx_xvshuf_b(high_elem, high_elem, high_idx);
+
+			// accumulation on GF(2^8)
+			res1 = __lasx_xvxor_v(res1, __lasx_xvxor_v(low_val, high_val));
+
+			/* =================== for row 1 =================== */
+			// fetch one element from gftbls, which is 32 bytes
+			low_elem = __lasx_xvldx(gftbls, col_offset + skip1);
+			high_elem = low_elem;
+
+			// duplicate low part
+			low_elem = __lasx_xvpermi_d(low_elem, 0x44);
+
+			// duplicate high part
+			high_elem = __lasx_xvpermi_d(high_elem, 0xEE);
+
+			// pick by low_idx
+			low_val = __lasx_xvshuf_b(low_elem, low_elem, low_idx);
+
+			// pick by high_idx
+			high_val = __lasx_xvshuf_b(high_elem, high_elem, high_idx);
+
+			// accumulation on GF(2^8)
+			res2 = __lasx_xvxor_v(res2, __lasx_xvxor_v(low_val, high_val));
+
+			/* =================== for row 2 =================== */
+			// fetch one element from gftbls, which is 32 bytes
+			low_elem = __lasx_xvldx(gftbls, col_offset + skip2);
+			high_elem = low_elem;
+
+			// duplicate low part
+			low_elem = __lasx_xvpermi_d(low_elem, 0x44);
+
+			// duplicate high part
+			high_elem = __lasx_xvpermi_d(high_elem, 0xEE);
+
+			// pick by low_idx
+			low_val = __lasx_xvshuf_b(low_elem, low_elem, low_idx);
+
+			// pick by high_idx
+			high_val = __lasx_xvshuf_b(high_elem, high_elem, high_idx);
+
+			// accumulation on GF(2^8)
+			res3 = __lasx_xvxor_v(res3, __lasx_xvxor_v(low_val, high_val));
+
+			/* =================== for row 3 =================== */
+			// fetch one element from gftbls, which is 32 bytes
+			low_elem = __lasx_xvldx(gftbls, col_offset + skip3);
+			high_elem = low_elem;
+
+			// duplicate low part
+			low_elem = __lasx_xvpermi_d(low_elem, 0x44);
+
+			// duplicate high part
+			high_elem = __lasx_xvpermi_d(high_elem, 0xEE);
+
+			// pick by low_idx
+			low_val = __lasx_xvshuf_b(low_elem, low_elem, low_idx);
+
+			// pick by high_idx
+			high_val = __lasx_xvshuf_b(high_elem, high_elem, high_idx);
+
+			// accumulation on GF(2^8)
+			res4 = __lasx_xvxor_v(res4, __lasx_xvxor_v(low_val, high_val));
+
+			/* =================== for row 4 =================== */
+			// fetch one element from gftbls, which is 32 bytes
+			low_elem = __lasx_xvldx(gftbls, col_offset + (skip2 << 1));
+			high_elem = low_elem;
+
+			// duplicate low part
+			low_elem = __lasx_xvpermi_d(low_elem, 0x44);
+
+			// duplicate high part
+			high_elem = __lasx_xvpermi_d(high_elem, 0xEE);
+
+			// pick by low_idx
+			low_val = __lasx_xvshuf_b(low_elem, low_elem, low_idx);
+
+			// pick by high_idx
+			high_val = __lasx_xvshuf_b(high_elem, high_elem, high_idx);
+
+			// accumulation on GF(2^8)
+			res5 = __lasx_xvxor_v(res5, __lasx_xvxor_v(low_val, high_val));
+
+			/* =================== for row 5 =================== */
+			// fetch one element from gftbls, which is 32 bytes
+			low_elem = __lasx_xvldx(gftbls, col_offset + (skip2 + skip3));
+			high_elem = low_elem;
+
+			// duplicate low part
+			low_elem = __lasx_xvpermi_d(low_elem, 0x44);
+
+			// duplicate high part
+			high_elem = __lasx_xvpermi_d(high_elem, 0xEE);
+
+			// pick by low_idx
+			low_val = __lasx_xvshuf_b(low_elem, low_elem, low_idx);
+
+			// pick by high_idx
+			high_val = __lasx_xvshuf_b(high_elem, high_elem, high_idx);
+
+			// accumulation on GF(2^8)
+			res6 = __lasx_xvxor_v(res6, __lasx_xvxor_v(low_val, high_val));
+		}
+
+		__lasx_xvstx(res1, dest[0], buf_offset);
+		__lasx_xvstx(res2, dest[1], buf_offset);
+		__lasx_xvstx(res3, dest[2], buf_offset);
+		__lasx_xvstx(res4, dest[3], buf_offset);
+		__lasx_xvstx(res5, dest[4], buf_offset);
+		__lasx_xvstx(res6, dest[5], buf_offset);
+	}
+
+	if (remain == 0)
+		return;
+
+	// handle remain bytes
+	i = block_count << 5;
+	while (remain >= 8) {
+		for (l = 0; l < 6; ++l) {
+			sul = 0;
+			for (j = 0; j < vlen; ++j) {
+				index = *(unsigned long *)&src[j][i];
+				pos = &gftbls[(j << 5) + l * skip1];
+
+				tmp = pos[index & 0xF] ^ pos[16 + ((index >> 4) & 0xF)];
+				index = index >> 8;
+				tmp |= (unsigned long)(pos[index & 0xF] ^ pos[16 + ((index >> 4) & 0xF)]) << 8;
+				index = index >> 8;
+				tmp |= (unsigned long)(pos[index & 0xF] ^ pos[16 + ((index >> 4) & 0xF)]) << 16;
+				index = index >> 8;
+				tmp |= (unsigned long)(pos[index & 0xF] ^ pos[16 + ((index >> 4) & 0xF)]) << 24;
+				index = index >> 8;
+				tmp |= (unsigned long)(pos[index & 0xF] ^ pos[16 + ((index >> 4) & 0xF)]) << 32;
+				index = index >> 8;
+				tmp |= (unsigned long)(pos[index & 0xF] ^ pos[16 + ((index >> 4) & 0xF)]) << 40;
+				index = index >> 8;
+				tmp |= (unsigned long)(pos[index & 0xF] ^ pos[16 + ((index >> 4) & 0xF)]) << 48;
+				index = index >> 8;
+				tmp |= (unsigned long)(pos[index & 0xF] ^ pos[16 + ((index >> 4) & 0xF)]) << 56;
+
+				sul ^= tmp;
+			}
+			*(unsigned long *)&dest[l][i] = sul;
+		}
+		i += sizeof(unsigned long);
+		remain -= sizeof(unsigned long);
+	}
+
+	if (remain == 0)
+		return;
+
+	buf_offset = i;
+	for (l = 0; l < 6; l++) {
+		for (i = buf_offset; i < len; i++) {
+			suc = 0;
+			for (j = 0; j < vlen; j++) {
+				sval = src[j][i];
+				pos = &gftbls[(j << 5) + l * skip1];
+				suc ^= pos[sval & 0xF] ^ pos[16 + (sval >> 4)];
+			}
+			dest[l][i] = suc;
+		}
+	}
+}

--- a/erasure_code/loongarch64/gf_6vect_dot_prod_lasx_test.c
+++ b/erasure_code/loongarch64/gf_6vect_dot_prod_lasx_test.c
@@ -1,0 +1,912 @@
+/**********************************************************************
+  Copyright(c) 2011-2015 Intel Corporation All rights reserved.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions
+  are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in
+      the documentation and/or other materials provided with the
+      distribution.
+    * Neither the name of Intel Corporation nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+**********************************************************************/
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>		// for memset, memcmp
+#include "erasure_code.h"
+#include "ec_loongarch64.h"
+#include "types.h"
+
+#ifndef FUNCTION_UNDER_TEST
+# define FUNCTION_UNDER_TEST gf_6vect_dot_prod_lasx
+#endif
+#ifndef TEST_MIN_SIZE
+# define TEST_MIN_SIZE  16
+#endif
+
+#define str(s) #s
+#define xstr(s) str(s)
+
+#define TEST_LEN (8192+31)
+#define TEST_SIZE (TEST_LEN/2)
+#define TEST_MEM  TEST_SIZE
+#define TEST_LOOPS 20000
+#define TEST_TYPE_STR ""
+
+#ifndef TEST_SOURCES
+# define TEST_SOURCES  16
+#endif
+#ifndef RANDOMS
+# define RANDOMS 20
+#endif
+
+#ifdef EC_ALIGNED_ADDR
+// Define power of 2 range to check ptr, len alignment
+# define PTR_ALIGN_CHK_B 0
+# define LEN_ALIGN_CHK_B 0	// 0 for aligned only
+#else
+// Define power of 2 range to check ptr, len alignment
+# define PTR_ALIGN_CHK_B 32
+# define LEN_ALIGN_CHK_B 32	// 0 for aligned only
+#endif
+
+typedef unsigned char u8;
+
+void dump(unsigned char *buf, int len)
+{
+	int i;
+	for (i = 0; i < len;) {
+		printf(" %2x", 0xff & buf[i++]);
+		if (i % 32 == 0)
+			printf("\n");
+	}
+	printf("\n");
+}
+
+void dump_matrix(unsigned char **s, int k, int m)
+{
+	int i, j;
+	for (i = 0; i < k; i++) {
+		for (j = 0; j < m; j++) {
+			printf(" %2x", s[i][j]);
+		}
+		printf("\n");
+	}
+	printf("\n");
+}
+
+void dump_u8xu8(unsigned char *s, int k, int m)
+{
+	int i, j;
+	for (i = 0; i < k; i++) {
+		for (j = 0; j < m; j++) {
+			printf(" %2x", 0xff & s[j + (i * m)]);
+		}
+		printf("\n");
+	}
+	printf("\n");
+}
+
+int main(int argc, char *argv[])
+{
+	int i, j, rtest, srcs;
+	void *buf;
+	u8 g1[TEST_SOURCES], g2[TEST_SOURCES], g3[TEST_SOURCES];
+	u8 g4[TEST_SOURCES], g5[TEST_SOURCES], g6[TEST_SOURCES], *g_tbls;
+	u8 *dest1, *dest2, *dest3, *dest4, *dest5, *dest6, *dest_ref1;
+	u8 *dest_ref2, *dest_ref3, *dest_ref4, *dest_ref5, *dest_ref6;
+	u8 *dest_ptrs[6], *buffs[TEST_SOURCES];
+
+	int align, size;
+	unsigned char *efence_buffs[TEST_SOURCES];
+	unsigned int offset;
+	u8 *ubuffs[TEST_SOURCES];
+	u8 *udest_ptrs[6];
+	printf(xstr(FUNCTION_UNDER_TEST) ": %dx%d ", TEST_SOURCES, TEST_LEN);
+
+	// Allocate the arrays
+	for (i = 0; i < TEST_SOURCES; i++) {
+		if (posix_memalign(&buf, 64, TEST_LEN)) {
+			printf("alloc error: Fail");
+			return -1;
+		}
+		buffs[i] = buf;
+	}
+
+	if (posix_memalign(&buf, 16, 2 * (6 * TEST_SOURCES * 32))) {
+		printf("alloc error: Fail");
+		return -1;
+	}
+	g_tbls = buf;
+
+	if (posix_memalign(&buf, 64, TEST_LEN)) {
+		printf("alloc error: Fail");
+		return -1;
+	}
+	dest1 = buf;
+
+	if (posix_memalign(&buf, 64, TEST_LEN)) {
+		printf("alloc error: Fail");
+		return -1;
+	}
+	dest2 = buf;
+
+	if (posix_memalign(&buf, 64, TEST_LEN)) {
+		printf("alloc error: Fail");
+		return -1;
+	}
+	dest3 = buf;
+
+	if (posix_memalign(&buf, 64, TEST_LEN)) {
+		printf("alloc error: Fail");
+		return -1;
+	}
+	dest4 = buf;
+
+	if (posix_memalign(&buf, 64, TEST_LEN)) {
+		printf("alloc error: Fail");
+		return -1;
+	}
+	dest5 = buf;
+
+	if (posix_memalign(&buf, 64, TEST_LEN)) {
+		printf("alloc error: Fail");
+		return -1;
+	}
+	dest6 = buf;
+
+	if (posix_memalign(&buf, 64, TEST_LEN)) {
+		printf("alloc error: Fail");
+		return -1;
+	}
+	dest_ref1 = buf;
+
+	if (posix_memalign(&buf, 64, TEST_LEN)) {
+		printf("alloc error: Fail");
+		return -1;
+	}
+	dest_ref2 = buf;
+
+	if (posix_memalign(&buf, 64, TEST_LEN)) {
+		printf("alloc error: Fail");
+		return -1;
+	}
+	dest_ref3 = buf;
+
+	if (posix_memalign(&buf, 64, TEST_LEN)) {
+		printf("alloc error: Fail");
+		return -1;
+	}
+	dest_ref4 = buf;
+
+	if (posix_memalign(&buf, 64, TEST_LEN)) {
+		printf("alloc error: Fail");
+		return -1;
+	}
+	dest_ref5 = buf;
+
+	if (posix_memalign(&buf, 64, TEST_LEN)) {
+		printf("alloc error: Fail");
+		return -1;
+	}
+	dest_ref6 = buf;
+
+	dest_ptrs[0] = dest1;
+	dest_ptrs[1] = dest2;
+	dest_ptrs[2] = dest3;
+	dest_ptrs[3] = dest4;
+	dest_ptrs[4] = dest5;
+	dest_ptrs[5] = dest6;
+
+	// Test of all zeros
+	for (i = 0; i < TEST_SOURCES; i++)
+		memset(buffs[i], 0, TEST_LEN);
+
+	memset(dest1, 0, TEST_LEN);
+	memset(dest2, 0, TEST_LEN);
+	memset(dest3, 0, TEST_LEN);
+	memset(dest4, 0, TEST_LEN);
+	memset(dest5, 0, TEST_LEN);
+	memset(dest6, 0, TEST_LEN);
+	memset(dest_ref1, 0, TEST_LEN);
+	memset(dest_ref2, 0, TEST_LEN);
+	memset(dest_ref3, 0, TEST_LEN);
+	memset(dest_ref4, 0, TEST_LEN);
+	memset(dest_ref5, 0, TEST_LEN);
+	memset(dest_ref6, 0, TEST_LEN);
+	memset(g1, 2, TEST_SOURCES);
+	memset(g2, 1, TEST_SOURCES);
+	memset(g3, 7, TEST_SOURCES);
+	memset(g4, 9, TEST_SOURCES);
+	memset(g5, 4, TEST_SOURCES);
+	memset(g6, 0xe6, TEST_SOURCES);
+
+	for (i = 0; i < TEST_SOURCES; i++) {
+		gf_vect_mul_init(g1[i], &g_tbls[i * 32]);
+		gf_vect_mul_init(g2[i], &g_tbls[32 * TEST_SOURCES + i * 32]);
+		gf_vect_mul_init(g3[i], &g_tbls[64 * TEST_SOURCES + i * 32]);
+		gf_vect_mul_init(g4[i], &g_tbls[96 * TEST_SOURCES + i * 32]);
+		gf_vect_mul_init(g5[i], &g_tbls[128 * TEST_SOURCES + i * 32]);
+		gf_vect_mul_init(g6[i], &g_tbls[160 * TEST_SOURCES + i * 32]);
+	}
+
+	gf_vect_dot_prod_base(TEST_LEN, TEST_SOURCES, &g_tbls[0], buffs, dest_ref1);
+	gf_vect_dot_prod_base(TEST_LEN, TEST_SOURCES, &g_tbls[32 * TEST_SOURCES], buffs,
+			      dest_ref2);
+	gf_vect_dot_prod_base(TEST_LEN, TEST_SOURCES, &g_tbls[64 * TEST_SOURCES], buffs,
+			      dest_ref3);
+	gf_vect_dot_prod_base(TEST_LEN, TEST_SOURCES, &g_tbls[96 * TEST_SOURCES], buffs,
+			      dest_ref4);
+	gf_vect_dot_prod_base(TEST_LEN, TEST_SOURCES, &g_tbls[128 * TEST_SOURCES], buffs,
+			      dest_ref5);
+	gf_vect_dot_prod_base(TEST_LEN, TEST_SOURCES, &g_tbls[160 * TEST_SOURCES], buffs,
+			      dest_ref6);
+
+	FUNCTION_UNDER_TEST(TEST_LEN, TEST_SOURCES, g_tbls, buffs, dest_ptrs);
+
+	if (0 != memcmp(dest_ref1, dest1, TEST_LEN)) {
+		printf("Fail zero " xstr(FUNCTION_UNDER_TEST) " test1\n");
+		dump_matrix(buffs, 5, TEST_SOURCES);
+		printf("dprod_base:");
+		dump(dest_ref1, 25);
+		printf("dprod_dut:");
+		dump(dest1, 25);
+		return -1;
+	}
+	if (0 != memcmp(dest_ref2, dest2, TEST_LEN)) {
+		printf("Fail zero " xstr(FUNCTION_UNDER_TEST) " test2\n");
+		dump_matrix(buffs, 5, TEST_SOURCES);
+		printf("dprod_base:");
+		dump(dest_ref2, 25);
+		printf("dprod_dut:");
+		dump(dest2, 25);
+		return -1;
+	}
+	if (0 != memcmp(dest_ref3, dest3, TEST_LEN)) {
+		printf("Fail zero " xstr(FUNCTION_UNDER_TEST) " test3\n");
+		dump_matrix(buffs, 5, TEST_SOURCES);
+		printf("dprod_base:");
+		dump(dest_ref3, 25);
+		printf("dprod_dut:");
+		dump(dest3, 25);
+		return -1;
+	}
+	if (0 != memcmp(dest_ref4, dest4, TEST_LEN)) {
+		printf("Fail zero " xstr(FUNCTION_UNDER_TEST) " test4\n");
+		dump_matrix(buffs, 5, TEST_SOURCES);
+		printf("dprod_base:");
+		dump(dest_ref4, 25);
+		printf("dprod_dut:");
+		dump(dest4, 25);
+		return -1;
+	}
+	if (0 != memcmp(dest_ref5, dest5, TEST_LEN)) {
+		printf("Fail zero " xstr(FUNCTION_UNDER_TEST) " test5\n");
+		dump_matrix(buffs, 5, TEST_SOURCES);
+		printf("dprod_base:");
+		dump(dest_ref5, 25);
+		printf("dprod_dut:");
+		dump(dest5, 25);
+		return -1;
+	}
+	if (0 != memcmp(dest_ref6, dest6, TEST_LEN)) {
+		printf("Fail zero " xstr(FUNCTION_UNDER_TEST) " test6\n");
+		dump_matrix(buffs, 5, TEST_SOURCES);
+		printf("dprod_base:");
+		dump(dest_ref6, 25);
+		printf("dprod_dut:");
+		dump(dest6, 25);
+		return -1;
+	}
+	putchar('.');
+
+	// Rand data test
+
+	for (rtest = 0; rtest < RANDOMS; rtest++) {
+		for (i = 0; i < TEST_SOURCES; i++)
+			for (j = 0; j < TEST_LEN; j++)
+				buffs[i][j] = rand();
+
+		for (i = 0; i < TEST_SOURCES; i++) {
+			g1[i] = rand();
+			g2[i] = rand();
+			g3[i] = rand();
+			g4[i] = rand();
+			g5[i] = rand();
+			g6[i] = rand();
+		}
+
+		for (i = 0; i < TEST_SOURCES; i++) {
+			gf_vect_mul_init(g1[i], &g_tbls[i * 32]);
+			gf_vect_mul_init(g2[i], &g_tbls[(32 * TEST_SOURCES) + (i * 32)]);
+			gf_vect_mul_init(g3[i], &g_tbls[(64 * TEST_SOURCES) + (i * 32)]);
+			gf_vect_mul_init(g4[i], &g_tbls[(96 * TEST_SOURCES) + (i * 32)]);
+			gf_vect_mul_init(g5[i], &g_tbls[(128 * TEST_SOURCES) + (i * 32)]);
+			gf_vect_mul_init(g6[i], &g_tbls[(160 * TEST_SOURCES) + (i * 32)]);
+		}
+
+		gf_vect_dot_prod_base(TEST_LEN, TEST_SOURCES, &g_tbls[0], buffs, dest_ref1);
+		gf_vect_dot_prod_base(TEST_LEN, TEST_SOURCES, &g_tbls[32 * TEST_SOURCES],
+				      buffs, dest_ref2);
+		gf_vect_dot_prod_base(TEST_LEN, TEST_SOURCES, &g_tbls[64 * TEST_SOURCES],
+				      buffs, dest_ref3);
+		gf_vect_dot_prod_base(TEST_LEN, TEST_SOURCES, &g_tbls[96 * TEST_SOURCES],
+				      buffs, dest_ref4);
+		gf_vect_dot_prod_base(TEST_LEN, TEST_SOURCES, &g_tbls[128 * TEST_SOURCES],
+				      buffs, dest_ref5);
+		gf_vect_dot_prod_base(TEST_LEN, TEST_SOURCES, &g_tbls[160 * TEST_SOURCES],
+				      buffs, dest_ref6);
+
+		FUNCTION_UNDER_TEST(TEST_LEN, TEST_SOURCES, g_tbls, buffs, dest_ptrs);
+
+		if (0 != memcmp(dest_ref1, dest1, TEST_LEN)) {
+			printf("Fail rand " xstr(FUNCTION_UNDER_TEST) " test1 %d\n", rtest);
+			dump_matrix(buffs, 5, TEST_SOURCES);
+			printf("dprod_base:");
+			dump(dest_ref1, 25);
+			printf("dprod_dut:");
+			dump(dest1, 25);
+			return -1;
+		}
+		if (0 != memcmp(dest_ref2, dest2, TEST_LEN)) {
+			printf("Fail rand " xstr(FUNCTION_UNDER_TEST) " test2 %d\n", rtest);
+			dump_matrix(buffs, 5, TEST_SOURCES);
+			printf("dprod_base:");
+			dump(dest_ref2, 25);
+			printf("dprod_dut:");
+			dump(dest2, 25);
+			return -1;
+		}
+		if (0 != memcmp(dest_ref3, dest3, TEST_LEN)) {
+			printf("Fail rand " xstr(FUNCTION_UNDER_TEST) " test3 %d\n", rtest);
+			dump_matrix(buffs, 5, TEST_SOURCES);
+			printf("dprod_base:");
+			dump(dest_ref3, 25);
+			printf("dprod_dut:");
+			dump(dest3, 25);
+			return -1;
+		}
+		if (0 != memcmp(dest_ref4, dest4, TEST_LEN)) {
+			printf("Fail rand " xstr(FUNCTION_UNDER_TEST) " test4 %d\n", rtest);
+			dump_matrix(buffs, 5, TEST_SOURCES);
+			printf("dprod_base:");
+			dump(dest_ref4, 25);
+			printf("dprod_dut:");
+			dump(dest4, 25);
+			return -1;
+		}
+		if (0 != memcmp(dest_ref5, dest5, TEST_LEN)) {
+			printf("Fail rand " xstr(FUNCTION_UNDER_TEST) " test5 %d\n", rtest);
+			dump_matrix(buffs, 5, TEST_SOURCES);
+			printf("dprod_base:");
+			dump(dest_ref5, 25);
+			printf("dprod_dut:");
+			dump(dest5, 25);
+			return -1;
+		}
+		if (0 != memcmp(dest_ref6, dest6, TEST_LEN)) {
+			printf("Fail rand " xstr(FUNCTION_UNDER_TEST) " test6 %d\n", rtest);
+			dump_matrix(buffs, 5, TEST_SOURCES);
+			printf("dprod_base:");
+			dump(dest_ref6, 25);
+			printf("dprod_dut:");
+			dump(dest6, 25);
+			return -1;
+		}
+
+		putchar('.');
+	}
+
+	// Rand data test with varied parameters
+	for (rtest = 0; rtest < RANDOMS; rtest++) {
+		for (srcs = TEST_SOURCES; srcs > 0; srcs--) {
+			for (i = 0; i < srcs; i++)
+				for (j = 0; j < TEST_LEN; j++)
+					buffs[i][j] = rand();
+
+			for (i = 0; i < srcs; i++) {
+				g1[i] = rand();
+				g2[i] = rand();
+				g3[i] = rand();
+				g4[i] = rand();
+				g5[i] = rand();
+				g6[i] = rand();
+			}
+
+			for (i = 0; i < srcs; i++) {
+				gf_vect_mul_init(g1[i], &g_tbls[i * 32]);
+				gf_vect_mul_init(g2[i], &g_tbls[(32 * srcs) + (i * 32)]);
+				gf_vect_mul_init(g3[i], &g_tbls[(64 * srcs) + (i * 32)]);
+				gf_vect_mul_init(g4[i], &g_tbls[(96 * srcs) + (i * 32)]);
+				gf_vect_mul_init(g5[i], &g_tbls[(128 * srcs) + (i * 32)]);
+				gf_vect_mul_init(g6[i], &g_tbls[(160 * srcs) + (i * 32)]);
+			}
+
+			gf_vect_dot_prod_base(TEST_LEN, srcs, &g_tbls[0], buffs, dest_ref1);
+			gf_vect_dot_prod_base(TEST_LEN, srcs, &g_tbls[32 * srcs], buffs,
+					      dest_ref2);
+			gf_vect_dot_prod_base(TEST_LEN, srcs, &g_tbls[64 * srcs], buffs,
+					      dest_ref3);
+			gf_vect_dot_prod_base(TEST_LEN, srcs, &g_tbls[96 * srcs], buffs,
+					      dest_ref4);
+			gf_vect_dot_prod_base(TEST_LEN, srcs, &g_tbls[128 * srcs], buffs,
+					      dest_ref5);
+			gf_vect_dot_prod_base(TEST_LEN, srcs, &g_tbls[160 * srcs], buffs,
+					      dest_ref6);
+
+			FUNCTION_UNDER_TEST(TEST_LEN, srcs, g_tbls, buffs, dest_ptrs);
+
+			if (0 != memcmp(dest_ref1, dest1, TEST_LEN)) {
+				printf("Fail rand " xstr(FUNCTION_UNDER_TEST)
+				       " test1 srcs=%d\n", srcs);
+				dump_matrix(buffs, 5, TEST_SOURCES);
+				printf("dprod_base:");
+				dump(dest_ref1, 25);
+				printf("dprod_dut:");
+				dump(dest1, 25);
+				return -1;
+			}
+			if (0 != memcmp(dest_ref2, dest2, TEST_LEN)) {
+				printf("Fail rand " xstr(FUNCTION_UNDER_TEST)
+				       " test2 srcs=%d\n", srcs);
+				dump_matrix(buffs, 5, TEST_SOURCES);
+				printf("dprod_base:");
+				dump(dest_ref2, 25);
+				printf("dprod_dut:");
+				dump(dest2, 25);
+				return -1;
+			}
+			if (0 != memcmp(dest_ref3, dest3, TEST_LEN)) {
+				printf("Fail rand " xstr(FUNCTION_UNDER_TEST)
+				       " test3 srcs=%d\n", srcs);
+				dump_matrix(buffs, 5, TEST_SOURCES);
+				printf("dprod_base:");
+				dump(dest_ref3, 25);
+				printf("dprod_dut:");
+				dump(dest3, 25);
+				return -1;
+			}
+			if (0 != memcmp(dest_ref4, dest4, TEST_LEN)) {
+				printf("Fail rand " xstr(FUNCTION_UNDER_TEST)
+				       " test4 srcs=%d\n", srcs);
+				dump_matrix(buffs, 5, TEST_SOURCES);
+				printf("dprod_base:");
+				dump(dest_ref4, 25);
+				printf("dprod_dut:");
+				dump(dest4, 25);
+				return -1;
+			}
+			if (0 != memcmp(dest_ref5, dest5, TEST_LEN)) {
+				printf("Fail rand " xstr(FUNCTION_UNDER_TEST)
+				       " test5 srcs=%d\n", srcs);
+				dump_matrix(buffs, 5, TEST_SOURCES);
+				printf("dprod_base:");
+				dump(dest_ref5, 25);
+				printf("dprod_dut:");
+				dump(dest5, 25);
+				return -1;
+			}
+			if (0 != memcmp(dest_ref6, dest6, TEST_LEN)) {
+				printf("Fail rand " xstr(FUNCTION_UNDER_TEST)
+				       " test6 srcs=%d\n", srcs);
+				dump_matrix(buffs, 5, TEST_SOURCES);
+				printf("dprod_base:");
+				dump(dest_ref6, 25);
+				printf("dprod_dut:");
+				dump(dest6, 25);
+				return -1;
+			}
+
+			putchar('.');
+		}
+	}
+
+	// Run tests at end of buffer for Electric Fence
+	align = (LEN_ALIGN_CHK_B != 0) ? 1 : 16;
+	for (size = TEST_MIN_SIZE; size <= TEST_SIZE; size += align) {
+		for (i = 0; i < TEST_SOURCES; i++)
+			for (j = 0; j < TEST_LEN; j++)
+				buffs[i][j] = rand();
+
+		for (i = 0; i < TEST_SOURCES; i++)	// Line up TEST_SIZE from end
+			efence_buffs[i] = buffs[i] + TEST_LEN - size;
+
+		for (i = 0; i < TEST_SOURCES; i++) {
+			g1[i] = rand();
+			g2[i] = rand();
+			g3[i] = rand();
+			g4[i] = rand();
+			g5[i] = rand();
+			g6[i] = rand();
+		}
+
+		for (i = 0; i < TEST_SOURCES; i++) {
+			gf_vect_mul_init(g1[i], &g_tbls[i * 32]);
+			gf_vect_mul_init(g2[i], &g_tbls[(32 * TEST_SOURCES) + (i * 32)]);
+			gf_vect_mul_init(g3[i], &g_tbls[(64 * TEST_SOURCES) + (i * 32)]);
+			gf_vect_mul_init(g4[i], &g_tbls[(96 * TEST_SOURCES) + (i * 32)]);
+			gf_vect_mul_init(g5[i], &g_tbls[(128 * TEST_SOURCES) + (i * 32)]);
+			gf_vect_mul_init(g6[i], &g_tbls[(160 * TEST_SOURCES) + (i * 32)]);
+		}
+
+		gf_vect_dot_prod_base(size, TEST_SOURCES, &g_tbls[0], efence_buffs, dest_ref1);
+		gf_vect_dot_prod_base(size, TEST_SOURCES, &g_tbls[32 * TEST_SOURCES],
+				      efence_buffs, dest_ref2);
+		gf_vect_dot_prod_base(size, TEST_SOURCES, &g_tbls[64 * TEST_SOURCES],
+				      efence_buffs, dest_ref3);
+		gf_vect_dot_prod_base(size, TEST_SOURCES, &g_tbls[96 * TEST_SOURCES],
+				      efence_buffs, dest_ref4);
+		gf_vect_dot_prod_base(size, TEST_SOURCES, &g_tbls[128 * TEST_SOURCES],
+				      efence_buffs, dest_ref5);
+		gf_vect_dot_prod_base(size, TEST_SOURCES, &g_tbls[160 * TEST_SOURCES],
+				      efence_buffs, dest_ref6);
+
+		FUNCTION_UNDER_TEST(size, TEST_SOURCES, g_tbls, efence_buffs, dest_ptrs);
+
+		if (0 != memcmp(dest_ref1, dest1, size)) {
+			printf("Fail rand " xstr(FUNCTION_UNDER_TEST) " test1 %d\n", rtest);
+			dump_matrix(efence_buffs, 5, TEST_SOURCES);
+			printf("dprod_base:");
+			dump(dest_ref1, align);
+			printf("dprod_dut:");
+			dump(dest1, align);
+			return -1;
+		}
+
+		if (0 != memcmp(dest_ref2, dest2, size)) {
+			printf("Fail rand " xstr(FUNCTION_UNDER_TEST) " test2 %d\n", rtest);
+			dump_matrix(efence_buffs, 5, TEST_SOURCES);
+			printf("dprod_base:");
+			dump(dest_ref2, align);
+			printf("dprod_dut:");
+			dump(dest2, align);
+			return -1;
+		}
+
+		if (0 != memcmp(dest_ref3, dest3, size)) {
+			printf("Fail rand " xstr(FUNCTION_UNDER_TEST) " test3 %d\n", rtest);
+			dump_matrix(efence_buffs, 5, TEST_SOURCES);
+			printf("dprod_base:");
+			dump(dest_ref3, align);
+			printf("dprod_dut:");
+			dump(dest3, align);
+			return -1;
+		}
+
+		if (0 != memcmp(dest_ref4, dest4, size)) {
+			printf("Fail rand " xstr(FUNCTION_UNDER_TEST) " test4 %d\n", rtest);
+			dump_matrix(efence_buffs, 5, TEST_SOURCES);
+			printf("dprod_base:");
+			dump(dest_ref4, align);
+			printf("dprod_dut:");
+			dump(dest4, align);
+			return -1;
+		}
+
+		if (0 != memcmp(dest_ref5, dest5, size)) {
+			printf("Fail rand " xstr(FUNCTION_UNDER_TEST) " test5 %d\n", rtest);
+			dump_matrix(efence_buffs, 5, TEST_SOURCES);
+			printf("dprod_base:");
+			dump(dest_ref5, align);
+			printf("dprod_dut:");
+			dump(dest5, align);
+			return -1;
+		}
+
+		if (0 != memcmp(dest_ref6, dest6, size)) {
+			printf("Fail rand " xstr(FUNCTION_UNDER_TEST) " test6 %d\n", rtest);
+			dump_matrix(efence_buffs, 5, TEST_SOURCES);
+			printf("dprod_base:");
+			dump(dest_ref6, align);
+			printf("dprod_dut:");
+			dump(dest6, align);
+			return -1;
+		}
+
+		putchar('.');
+	}
+
+	// Test rand ptr alignment if available
+
+	for (rtest = 0; rtest < RANDOMS; rtest++) {
+		size = (TEST_LEN - PTR_ALIGN_CHK_B) & ~(TEST_MIN_SIZE - 1);
+		srcs = rand() % TEST_SOURCES;
+		if (srcs == 0)
+			continue;
+
+		offset = (PTR_ALIGN_CHK_B != 0) ? 1 : PTR_ALIGN_CHK_B;
+		// Add random offsets
+		for (i = 0; i < srcs; i++)
+			ubuffs[i] = buffs[i] + (rand() & (PTR_ALIGN_CHK_B - offset));
+
+		udest_ptrs[0] = dest1 + (rand() & (PTR_ALIGN_CHK_B - offset));
+		udest_ptrs[1] = dest2 + (rand() & (PTR_ALIGN_CHK_B - offset));
+		udest_ptrs[2] = dest3 + (rand() & (PTR_ALIGN_CHK_B - offset));
+		udest_ptrs[3] = dest4 + (rand() & (PTR_ALIGN_CHK_B - offset));
+		udest_ptrs[4] = dest5 + (rand() & (PTR_ALIGN_CHK_B - offset));
+		udest_ptrs[5] = dest6 + (rand() & (PTR_ALIGN_CHK_B - offset));
+
+		memset(dest1, 0, TEST_LEN);	// zero pad to check write-over
+		memset(dest2, 0, TEST_LEN);
+		memset(dest3, 0, TEST_LEN);
+		memset(dest4, 0, TEST_LEN);
+		memset(dest5, 0, TEST_LEN);
+		memset(dest6, 0, TEST_LEN);
+
+		for (i = 0; i < srcs; i++)
+			for (j = 0; j < size; j++)
+				ubuffs[i][j] = rand();
+
+		for (i = 0; i < srcs; i++) {
+			g1[i] = rand();
+			g2[i] = rand();
+			g3[i] = rand();
+			g4[i] = rand();
+			g5[i] = rand();
+			g6[i] = rand();
+		}
+
+		for (i = 0; i < srcs; i++) {
+			gf_vect_mul_init(g1[i], &g_tbls[i * 32]);
+			gf_vect_mul_init(g2[i], &g_tbls[(32 * srcs) + (i * 32)]);
+			gf_vect_mul_init(g3[i], &g_tbls[(64 * srcs) + (i * 32)]);
+			gf_vect_mul_init(g4[i], &g_tbls[(96 * srcs) + (i * 32)]);
+			gf_vect_mul_init(g5[i], &g_tbls[(128 * srcs) + (i * 32)]);
+			gf_vect_mul_init(g6[i], &g_tbls[(160 * srcs) + (i * 32)]);
+		}
+
+		gf_vect_dot_prod_base(size, srcs, &g_tbls[0], ubuffs, dest_ref1);
+		gf_vect_dot_prod_base(size, srcs, &g_tbls[32 * srcs], ubuffs, dest_ref2);
+		gf_vect_dot_prod_base(size, srcs, &g_tbls[64 * srcs], ubuffs, dest_ref3);
+		gf_vect_dot_prod_base(size, srcs, &g_tbls[96 * srcs], ubuffs, dest_ref4);
+		gf_vect_dot_prod_base(size, srcs, &g_tbls[128 * srcs], ubuffs, dest_ref5);
+		gf_vect_dot_prod_base(size, srcs, &g_tbls[160 * srcs], ubuffs, dest_ref6);
+
+		FUNCTION_UNDER_TEST(size, srcs, g_tbls, ubuffs, udest_ptrs);
+
+		if (memcmp(dest_ref1, udest_ptrs[0], size)) {
+			printf("Fail rand " xstr(FUNCTION_UNDER_TEST) " test ualign srcs=%d\n",
+			       srcs);
+			dump_matrix(ubuffs, 5, TEST_SOURCES);
+			printf("dprod_base:");
+			dump(dest_ref1, 25);
+			printf("dprod_dut:");
+			dump(udest_ptrs[0], 25);
+			return -1;
+		}
+		if (memcmp(dest_ref2, udest_ptrs[1], size)) {
+			printf("Fail rand " xstr(FUNCTION_UNDER_TEST) " test ualign srcs=%d\n",
+			       srcs);
+			dump_matrix(ubuffs, 5, TEST_SOURCES);
+			printf("dprod_base:");
+			dump(dest_ref2, 25);
+			printf("dprod_dut:");
+			dump(udest_ptrs[1], 25);
+			return -1;
+		}
+		if (memcmp(dest_ref3, udest_ptrs[2], size)) {
+			printf("Fail rand " xstr(FUNCTION_UNDER_TEST) " test ualign srcs=%d\n",
+			       srcs);
+			dump_matrix(ubuffs, 5, TEST_SOURCES);
+			printf("dprod_base:");
+			dump(dest_ref3, 25);
+			printf("dprod_dut:");
+			dump(udest_ptrs[2], 25);
+			return -1;
+		}
+		if (memcmp(dest_ref4, udest_ptrs[3], size)) {
+			printf("Fail rand " xstr(FUNCTION_UNDER_TEST) " test ualign srcs=%d\n",
+			       srcs);
+			dump_matrix(ubuffs, 5, TEST_SOURCES);
+			printf("dprod_base:");
+			dump(dest_ref4, 25);
+			printf("dprod_dut:");
+			dump(udest_ptrs[3], 25);
+			return -1;
+		}
+		if (memcmp(dest_ref5, udest_ptrs[4], size)) {
+			printf("Fail rand " xstr(FUNCTION_UNDER_TEST) " test ualign srcs=%d\n",
+			       srcs);
+			dump_matrix(ubuffs, 5, TEST_SOURCES);
+			printf("dprod_base:");
+			dump(dest_ref5, 25);
+			printf("dprod_dut:");
+			dump(udest_ptrs[4], 25);
+			return -1;
+		}
+		if (memcmp(dest_ref6, udest_ptrs[5], size)) {
+			printf("Fail rand " xstr(FUNCTION_UNDER_TEST) " test ualign srcs=%d\n",
+			       srcs);
+			dump_matrix(ubuffs, 5, TEST_SOURCES);
+			printf("dprod_base:");
+			dump(dest_ref6, 25);
+			printf("dprod_dut:");
+			dump(udest_ptrs[5], 25);
+			return -1;
+		}
+		// Confirm that padding around dests is unchanged
+		memset(dest_ref1, 0, PTR_ALIGN_CHK_B);	// Make reference zero buff
+		offset = udest_ptrs[0] - dest1;
+
+		if (memcmp(dest1, dest_ref1, offset)) {
+			printf("Fail rand ualign pad1 start\n");
+			return -1;
+		}
+		if (memcmp(dest1 + offset + size, dest_ref1, PTR_ALIGN_CHK_B - offset)) {
+			printf("Fail rand ualign pad1 end\n");
+			return -1;
+		}
+
+		offset = udest_ptrs[1] - dest2;
+		if (memcmp(dest2, dest_ref1, offset)) {
+			printf("Fail rand ualign pad2 start\n");
+			return -1;
+		}
+		if (memcmp(dest2 + offset + size, dest_ref1, PTR_ALIGN_CHK_B - offset)) {
+			printf("Fail rand ualign pad2 end\n");
+			return -1;
+		}
+
+		offset = udest_ptrs[2] - dest3;
+		if (memcmp(dest3, dest_ref1, offset)) {
+			printf("Fail rand ualign pad3 start\n");
+			return -1;
+		}
+		if (memcmp(dest3 + offset + size, dest_ref1, PTR_ALIGN_CHK_B - offset)) {
+			printf("Fail rand ualign pad3 end\n");
+			return -1;
+		}
+
+		offset = udest_ptrs[3] - dest4;
+		if (memcmp(dest4, dest_ref1, offset)) {
+			printf("Fail rand ualign pad4 start\n");
+			return -1;
+		}
+		if (memcmp(dest4 + offset + size, dest_ref1, PTR_ALIGN_CHK_B - offset)) {
+			printf("Fail rand ualign pad4 end\n");
+			return -1;
+		}
+
+		offset = udest_ptrs[4] - dest5;
+		if (memcmp(dest5, dest_ref1, offset)) {
+			printf("Fail rand ualign pad5 start\n");
+			return -1;
+		}
+		if (memcmp(dest5 + offset + size, dest_ref1, PTR_ALIGN_CHK_B - offset)) {
+			printf("Fail rand ualign pad5 end\n");
+			return -1;
+		}
+
+		offset = udest_ptrs[5] - dest6;
+		if (memcmp(dest6, dest_ref1, offset)) {
+			printf("Fail rand ualign pad6 start\n");
+			return -1;
+		}
+		if (memcmp(dest6 + offset + size, dest_ref1, PTR_ALIGN_CHK_B - offset)) {
+			printf("Fail rand ualign pad6 end\n");
+			return -1;
+		}
+
+		putchar('.');
+	}
+
+	// Test all size alignment
+	align = (LEN_ALIGN_CHK_B != 0) ? 1 : 16;
+
+	for (size = TEST_LEN; size >= TEST_MIN_SIZE; size -= align) {
+		srcs = TEST_SOURCES;
+
+		for (i = 0; i < srcs; i++)
+			for (j = 0; j < size; j++)
+				buffs[i][j] = rand();
+
+		for (i = 0; i < srcs; i++) {
+			g1[i] = rand();
+			g2[i] = rand();
+			g3[i] = rand();
+			g4[i] = rand();
+			g5[i] = rand();
+			g6[i] = rand();
+		}
+
+		for (i = 0; i < srcs; i++) {
+			gf_vect_mul_init(g1[i], &g_tbls[i * 32]);
+			gf_vect_mul_init(g2[i], &g_tbls[(32 * srcs) + (i * 32)]);
+			gf_vect_mul_init(g3[i], &g_tbls[(64 * srcs) + (i * 32)]);
+			gf_vect_mul_init(g4[i], &g_tbls[(96 * srcs) + (i * 32)]);
+			gf_vect_mul_init(g5[i], &g_tbls[(128 * srcs) + (i * 32)]);
+			gf_vect_mul_init(g6[i], &g_tbls[(160 * srcs) + (i * 32)]);
+		}
+
+		gf_vect_dot_prod_base(size, srcs, &g_tbls[0], buffs, dest_ref1);
+		gf_vect_dot_prod_base(size, srcs, &g_tbls[32 * srcs], buffs, dest_ref2);
+		gf_vect_dot_prod_base(size, srcs, &g_tbls[64 * srcs], buffs, dest_ref3);
+		gf_vect_dot_prod_base(size, srcs, &g_tbls[96 * srcs], buffs, dest_ref4);
+		gf_vect_dot_prod_base(size, srcs, &g_tbls[128 * srcs], buffs, dest_ref5);
+		gf_vect_dot_prod_base(size, srcs, &g_tbls[160 * srcs], buffs, dest_ref6);
+
+		FUNCTION_UNDER_TEST(size, srcs, g_tbls, buffs, dest_ptrs);
+
+		if (memcmp(dest_ref1, dest_ptrs[0], size)) {
+			printf("Fail rand " xstr(FUNCTION_UNDER_TEST) " test ualign len=%d\n",
+			       size);
+			dump_matrix(buffs, 5, TEST_SOURCES);
+			printf("dprod_base:");
+			dump(dest_ref1, 25);
+			printf("dprod_dut:");
+			dump(dest_ptrs[0], 25);
+			return -1;
+		}
+		if (memcmp(dest_ref2, dest_ptrs[1], size)) {
+			printf("Fail rand " xstr(FUNCTION_UNDER_TEST) " test ualign len=%d\n",
+			       size);
+			dump_matrix(buffs, 5, TEST_SOURCES);
+			printf("dprod_base:");
+			dump(dest_ref2, 25);
+			printf("dprod_dut:");
+			dump(dest_ptrs[1], 25);
+			return -1;
+		}
+		if (memcmp(dest_ref3, dest_ptrs[2], size)) {
+			printf("Fail rand " xstr(FUNCTION_UNDER_TEST) " test ualign len=%d\n",
+			       size);
+			dump_matrix(buffs, 5, TEST_SOURCES);
+			printf("dprod_base:");
+			dump(dest_ref3, 25);
+			printf("dprod_dut:");
+			dump(dest_ptrs[2], 25);
+			return -1;
+		}
+		if (memcmp(dest_ref4, dest_ptrs[3], size)) {
+			printf("Fail rand " xstr(FUNCTION_UNDER_TEST) " test ualign len=%d\n",
+			       size);
+			dump_matrix(buffs, 5, TEST_SOURCES);
+			printf("dprod_base:");
+			dump(dest_ref4, 25);
+			printf("dprod_dut:");
+			dump(dest_ptrs[3], 25);
+			return -1;
+		}
+		if (memcmp(dest_ref5, dest_ptrs[4], size)) {
+			printf("Fail rand " xstr(FUNCTION_UNDER_TEST) " test ualign len=%d\n",
+			       size);
+			dump_matrix(buffs, 5, TEST_SOURCES);
+			printf("dprod_base:");
+			dump(dest_ref5, 25);
+			printf("dprod_dut:");
+			dump(dest_ptrs[4], 25);
+			return -1;
+		}
+		if (memcmp(dest_ref6, dest_ptrs[5], size)) {
+			printf("Fail rand " xstr(FUNCTION_UNDER_TEST) " test ualign len=%d\n",
+			       size);
+			dump_matrix(buffs, 5, TEST_SOURCES);
+			printf("dprod_base:");
+			dump(dest_ref6, 25);
+			printf("dprod_dut:");
+			dump(dest_ptrs[5], 25);
+			return -1;
+		}
+	}
+
+	printf("Pass\n");
+	return 0;
+
+}

--- a/erasure_code/loongarch64/gf_6vect_mad_lasx.c
+++ b/erasure_code/loongarch64/gf_6vect_mad_lasx.c
@@ -1,0 +1,269 @@
+/**********************************************************************
+  Copyright(c) 2022 Loongson Tech All rights reserved.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions
+  are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in
+      the documentation and/or other materials provided with the
+      distribution.
+    * Neither the name of Intel Corporation nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+**********************************************************************/
+
+#include <lasxintrin.h>
+
+void gf_6vect_mad_lasx(int len, int vec, int vec_i, unsigned char *gftbls,
+		       unsigned char *src, unsigned char **dest)
+{
+	int i, l;
+	int skip1 = vec << 5;
+	int skip2 = skip1 << 1;
+	int skip3 = skip1 + skip2;
+
+	int block_count = len >> 5;
+	int remain = len - (block_count << 5);
+	int buf_offset = 0, col_offset = vec_i << 5;
+
+	__m256i block, high_idx, low_idx;
+	__m256i high_elem, low_elem;
+       	__m256i	high_val, low_val;
+	__m256i res;
+
+	unsigned long index, tmp, tmp1;
+	unsigned char *pos;
+	unsigned char sval;
+
+	for (i = 0; i < block_count; ++i) {
+		/* read one block from src to update six rows */
+
+		buf_offset = i << 5;
+		// fetch one block from one buf into a vector variable,
+		// the block size is 32 bytes
+		block = __lasx_xvldx(src, buf_offset);
+
+		// get low indexes
+		low_idx = __lasx_xvandi_b(block, 0x0F);
+
+		// get high indexes: shift right 4 bits and add 0x10,
+		// which can index {0x10, ..., 0x1F}
+		high_idx = __lasx_xvori_b(__lasx_xvsrli_b(block, 4), 0x10);
+
+		/* =================== for row 0 =================== */
+		// fetch one element from gftbls, which is 32 bytes
+		low_elem = __lasx_xvldx(gftbls, col_offset);
+		high_elem = low_elem;
+
+		// duplicate low part
+		low_elem = __lasx_xvpermi_d(low_elem, 0x44);
+
+		// duplicate high part
+		high_elem = __lasx_xvpermi_d(high_elem, 0xEE);
+
+		// pick by low_idx
+		low_val = __lasx_xvshuf_b(low_elem, low_elem, low_idx);
+
+		// pick by high_idx
+		high_val = __lasx_xvshuf_b(high_elem, high_elem, high_idx);
+
+		// load old data
+		res = __lasx_xvldx(dest[0], buf_offset);
+
+		// accumulation on GF(2^8)
+		res = __lasx_xvxor_v(res, __lasx_xvxor_v(low_val, high_val));
+
+		// store new data
+		__lasx_xvstx(res, dest[0], buf_offset);
+
+		/* =================== for row 1 =================== */
+		// fetch one element from gftbls, which is 32 bytes
+		low_elem = __lasx_xvldx(gftbls, col_offset + skip1);
+		high_elem = low_elem;
+
+		// duplicate low part
+		low_elem = __lasx_xvpermi_d(low_elem, 0x44);
+
+		// duplicate high part
+		high_elem = __lasx_xvpermi_d(high_elem, 0xEE);
+
+		// pick by low_idx
+		low_val = __lasx_xvshuf_b(low_elem, low_elem, low_idx);
+
+		// pick by high_idx
+		high_val = __lasx_xvshuf_b(high_elem, high_elem, high_idx);
+
+		// load old data
+		res = __lasx_xvldx(dest[1], buf_offset);
+
+		// accumulation on GF(2^8)
+		res = __lasx_xvxor_v(res, __lasx_xvxor_v(low_val, high_val));
+
+		// store new data
+		__lasx_xvstx(res, dest[1], buf_offset);
+
+		/* =================== for row 2 =================== */
+		// fetch one element from gftbls, which is 32 bytes
+		low_elem = __lasx_xvldx(gftbls, col_offset + skip2);
+		high_elem = low_elem;
+
+		// duplicate low part
+		low_elem = __lasx_xvpermi_d(low_elem, 0x44);
+
+		// duplicate high part
+		high_elem = __lasx_xvpermi_d(high_elem, 0xEE);
+
+		// pick by low_idx
+		low_val = __lasx_xvshuf_b(low_elem, low_elem, low_idx);
+
+		// pick by high_idx
+		high_val = __lasx_xvshuf_b(high_elem, high_elem, high_idx);
+
+		// load old data
+		res = __lasx_xvldx(dest[2], buf_offset);
+
+		// accumulation on GF(2^8)
+		res = __lasx_xvxor_v(res, __lasx_xvxor_v(low_val, high_val));
+
+		// store new data
+		__lasx_xvstx(res, dest[2], buf_offset);
+
+		/* =================== for row 3 =================== */
+		// fetch one element from gftbls, which is 32 bytes
+		low_elem = __lasx_xvldx(gftbls, col_offset + skip3);
+		high_elem = low_elem;
+
+		// duplicate low part
+		low_elem = __lasx_xvpermi_d(low_elem, 0x44);
+
+		// duplicate high part
+		high_elem = __lasx_xvpermi_d(high_elem, 0xEE);
+
+		// pick by low_idx
+		low_val = __lasx_xvshuf_b(low_elem, low_elem, low_idx);
+
+		// pick by high_idx
+		high_val = __lasx_xvshuf_b(high_elem, high_elem, high_idx);
+
+		// load old data
+		res = __lasx_xvldx(dest[3], buf_offset);
+
+		// accumulation on GF(2^8)
+		res = __lasx_xvxor_v(res, __lasx_xvxor_v(low_val, high_val));
+
+		// store new data
+		__lasx_xvstx(res, dest[3], buf_offset);
+
+		/* =================== for row 4 =================== */
+		// fetch one element from gftbls, which is 32 bytes
+		low_elem = __lasx_xvldx(gftbls, col_offset + (skip2 << 1));
+		high_elem = low_elem;
+
+		// duplicate low part
+		low_elem = __lasx_xvpermi_d(low_elem, 0x44);
+
+		// duplicate high part
+		high_elem = __lasx_xvpermi_d(high_elem, 0xEE);
+
+		// pick by low_idx
+		low_val = __lasx_xvshuf_b(low_elem, low_elem, low_idx);
+
+		// pick by high_idx
+		high_val = __lasx_xvshuf_b(high_elem, high_elem, high_idx);
+
+		// load old data
+		res = __lasx_xvldx(dest[4], buf_offset);
+
+		// accumulation on GF(2^8)
+		res = __lasx_xvxor_v(res, __lasx_xvxor_v(low_val, high_val));
+
+		// store new data
+		__lasx_xvstx(res, dest[4], buf_offset);
+
+		/* =================== for row 5 =================== */
+		// fetch one element from gftbls, which is 32 bytes
+		low_elem = __lasx_xvldx(gftbls, col_offset + skip2 + skip3);
+		high_elem = low_elem;
+
+		// duplicate low part
+		low_elem = __lasx_xvpermi_d(low_elem, 0x44);
+
+		// duplicate high part
+		high_elem = __lasx_xvpermi_d(high_elem, 0xEE);
+
+		// pick by low_idx
+		low_val = __lasx_xvshuf_b(low_elem, low_elem, low_idx);
+
+		// pick by high_idx
+		high_val = __lasx_xvshuf_b(high_elem, high_elem, high_idx);
+
+		// load old data
+		res = __lasx_xvldx(dest[5], buf_offset);
+
+		// accumulation on GF(2^8)
+		res = __lasx_xvxor_v(res, __lasx_xvxor_v(low_val, high_val));
+
+		// store new data
+		__lasx_xvstx(res, dest[5], buf_offset);
+	}
+
+	if (remain == 0)
+		return;
+
+	// handle remain bytes
+	i = block_count << 5;
+	while (remain >= 8) {
+		tmp1 = *(unsigned long *)&src[i];
+		for (l = 0; l < 6; ++l) {
+			index = tmp1;
+			pos = &gftbls[col_offset + l * skip1];
+
+			tmp = pos[index & 0xF] ^ pos[16 + ((index >> 4) & 0xF)];
+			index = index >> 8;
+			tmp |= (unsigned long)(pos[index & 0xF] ^ pos[16 + ((index >> 4) & 0xF)]) << 8;
+			index = index >> 8;
+			tmp |= (unsigned long)(pos[index & 0xF] ^ pos[16 + ((index >> 4) & 0xF)]) << 16;
+			index = index >> 8;
+			tmp |= (unsigned long)(pos[index & 0xF] ^ pos[16 + ((index >> 4) & 0xF)]) << 24;
+			index = index >> 8;
+			tmp |= (unsigned long)(pos[index & 0xF] ^ pos[16 + ((index >> 4) & 0xF)]) << 32;
+			index = index >> 8;
+			tmp |= (unsigned long)(pos[index & 0xF] ^ pos[16 + ((index >> 4) & 0xF)]) << 40;
+			index = index >> 8;
+			tmp |= (unsigned long)(pos[index & 0xF] ^ pos[16 + ((index >> 4) & 0xF)]) << 48;
+			index = index >> 8;
+			tmp |= (unsigned long)(pos[index & 0xF] ^ pos[16 + ((index >> 4) & 0xF)]) << 56;
+
+			*(unsigned long *)&dest[l][i] ^= tmp;
+		}
+		i += sizeof(unsigned long);
+		remain -= sizeof(unsigned long);
+	}
+
+	if (remain == 0)
+		return;
+
+	buf_offset = i;
+	for (l = 0; l < 6; l++) {
+		for (i = buf_offset; i < len; i++) {
+			sval = src[i];
+			pos = &gftbls[col_offset + l * skip1];
+			dest[l][i] ^= pos[sval & 0xF] ^ pos[16 + (sval >> 4)];
+		}
+	}
+}

--- a/erasure_code/loongarch64/gf_6vect_mad_lasx_test.c
+++ b/erasure_code/loongarch64/gf_6vect_mad_lasx_test.c
@@ -1,0 +1,519 @@
+/**********************************************************************
+  Copyright(c) 2011-2015 Intel Corporation All rights reserved.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions
+  are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in
+      the documentation and/or other materials provided with the
+      distribution.
+    * Neither the name of Intel Corporation nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+**********************************************************************/
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>		// for memset, memcmp
+#include "erasure_code.h"
+#include "types.h"
+
+#ifndef ALIGN_SIZE
+# define ALIGN_SIZE 32
+#endif
+
+#ifndef FUNCTION_UNDER_TEST
+//By default, test multi-binary version
+# define FUNCTION_UNDER_TEST gf_6vect_mad_lasx
+# define REF_FUNCTION gf_6vect_dot_prod_lasx
+# define VECT 6
+#endif
+
+#ifndef TEST_MIN_SIZE
+# define TEST_MIN_SIZE 64
+#endif
+
+#define str(s) #s
+#define xstr(s) str(s)
+
+#define TEST_LEN (8192+31)
+#define TEST_SIZE (TEST_LEN/2)
+#define TEST_MEM  TEST_SIZE
+#define TEST_LOOPS 20000
+#define TEST_TYPE_STR ""
+
+#ifndef TEST_SOURCES
+# define TEST_SOURCES  16
+#endif
+#ifndef RANDOMS
+# define RANDOMS 20
+#endif
+
+#ifdef EC_ALIGNED_ADDR
+// Define power of 2 range to check ptr, len alignment
+# define PTR_ALIGN_CHK_B 0
+# define LEN_ALIGN_CHK_B 0	// 0 for aligned only
+#else
+// Define power of 2 range to check ptr, len alignment
+# define PTR_ALIGN_CHK_B ALIGN_SIZE
+# define LEN_ALIGN_CHK_B ALIGN_SIZE	// 0 for aligned only
+#endif
+
+#define str(s) #s
+#define xstr(s) str(s)
+
+typedef unsigned char u8;
+
+#if (VECT == 1)
+# define LAST_ARG *dest
+#else
+# define LAST_ARG **dest
+#endif
+
+extern void FUNCTION_UNDER_TEST(int len, int vec, int vec_i, unsigned char *gftbls,
+				unsigned char *src, unsigned char LAST_ARG);
+extern void REF_FUNCTION(int len, int vlen, unsigned char *gftbls, unsigned char **src,
+			 unsigned char LAST_ARG);
+
+void dump(unsigned char *buf, int len)
+{
+	int i;
+	for (i = 0; i < len;) {
+		printf(" %2x", 0xff & buf[i++]);
+		if (i % 32 == 0)
+			printf("\n");
+	}
+	printf("\n");
+}
+
+void dump_matrix(unsigned char **s, int k, int m)
+{
+	int i, j;
+	for (i = 0; i < k; i++) {
+		for (j = 0; j < m; j++) {
+			printf(" %2x", s[i][j]);
+		}
+		printf("\n");
+	}
+	printf("\n");
+}
+
+void dump_u8xu8(unsigned char *s, int k, int m)
+{
+	int i, j;
+	for (i = 0; i < k; i++) {
+		for (j = 0; j < m; j++) {
+			printf(" %2x", 0xff & s[j + (i * m)]);
+		}
+		printf("\n");
+	}
+	printf("\n");
+}
+
+int main(int argc, char *argv[])
+{
+	int i, j, rtest, srcs;
+	void *buf;
+	u8 gf[6][TEST_SOURCES];
+	u8 *g_tbls;
+	u8 *dest_ref[VECT];
+	u8 *dest_ptrs[VECT], *buffs[TEST_SOURCES];
+	int vector = VECT;
+
+	int align, size;
+	unsigned char *efence_buffs[TEST_SOURCES];
+	unsigned int offset;
+	u8 *ubuffs[TEST_SOURCES];
+	u8 *udest_ptrs[VECT];
+	printf("test" xstr(FUNCTION_UNDER_TEST) ": %dx%d ", TEST_SOURCES, TEST_LEN);
+
+	// Allocate the arrays
+	for (i = 0; i < TEST_SOURCES; i++) {
+		if (posix_memalign(&buf, 64, TEST_LEN)) {
+			printf("alloc error: Fail");
+			return -1;
+		}
+		buffs[i] = buf;
+	}
+
+	if (posix_memalign(&buf, 16, 2 * (vector * TEST_SOURCES * 32))) {
+		printf("alloc error: Fail");
+		return -1;
+	}
+	g_tbls = buf;
+
+	for (i = 0; i < vector; i++) {
+		if (posix_memalign(&buf, 64, TEST_LEN)) {
+			printf("alloc error: Fail");
+			return -1;
+		}
+		dest_ptrs[i] = buf;
+		memset(dest_ptrs[i], 0, TEST_LEN);
+	}
+
+	for (i = 0; i < vector; i++) {
+		if (posix_memalign(&buf, 64, TEST_LEN)) {
+			printf("alloc error: Fail");
+			return -1;
+		}
+		dest_ref[i] = buf;
+		memset(dest_ref[i], 0, TEST_LEN);
+	}
+
+	// Test of all zeros
+	for (i = 0; i < TEST_SOURCES; i++)
+		memset(buffs[i], 0, TEST_LEN);
+
+	switch (vector) {
+	case 6:
+		memset(gf[5], 0xe6, TEST_SOURCES);
+	case 5:
+		memset(gf[4], 4, TEST_SOURCES);
+	case 4:
+		memset(gf[3], 9, TEST_SOURCES);
+	case 3:
+		memset(gf[2], 7, TEST_SOURCES);
+	case 2:
+		memset(gf[1], 1, TEST_SOURCES);
+	case 1:
+		memset(gf[0], 2, TEST_SOURCES);
+		break;
+	default:
+		return -1;
+	}
+
+	for (i = 0; i < TEST_SOURCES; i++)
+		for (j = 0; j < TEST_LEN; j++)
+			buffs[i][j] = rand();
+
+	for (i = 0; i < vector; i++)
+		for (j = 0; j < TEST_SOURCES; j++) {
+			gf[i][j] = rand();
+			gf_vect_mul_init(gf[i][j], &g_tbls[i * (32 * TEST_SOURCES) + j * 32]);
+		}
+
+	for (i = 0; i < vector; i++)
+		gf_vect_dot_prod_base(TEST_LEN, TEST_SOURCES, &g_tbls[i * 32 * TEST_SOURCES],
+				      buffs, dest_ref[i]);
+
+	for (i = 0; i < vector; i++)
+		memset(dest_ptrs[i], 0, TEST_LEN);
+	for (i = 0; i < TEST_SOURCES; i++) {
+#if (VECT == 1)
+		FUNCTION_UNDER_TEST(TEST_LEN, TEST_SOURCES, i, g_tbls, buffs[i], *dest_ptrs);
+#else
+		FUNCTION_UNDER_TEST(TEST_LEN, TEST_SOURCES, i, g_tbls, buffs[i], dest_ptrs);
+#endif
+	}
+	for (i = 0; i < vector; i++) {
+		if (0 != memcmp(dest_ref[i], dest_ptrs[i], TEST_LEN)) {
+			printf("Fail zero " xstr(FUNCTION_UNDER_TEST) " test%d\n", i);
+			dump_matrix(buffs, vector, TEST_SOURCES);
+			printf("dprod_base:");
+			dump(dest_ref[i], 25);
+			printf("dprod_dut:");
+			dump(dest_ptrs[i], 25);
+			return -1;
+		}
+	}
+
+#if (VECT == 1)
+	REF_FUNCTION(TEST_LEN, TEST_SOURCES, g_tbls, buffs, *dest_ref);
+#else
+	REF_FUNCTION(TEST_LEN, TEST_SOURCES, g_tbls, buffs, dest_ref);
+#endif
+	for (i = 0; i < vector; i++) {
+		if (0 != memcmp(dest_ref[i], dest_ptrs[i], TEST_LEN)) {
+			printf("Fail zero " xstr(FUNCTION_UNDER_TEST) " test%d\n", i);
+			dump_matrix(buffs, vector, TEST_SOURCES);
+			printf("dprod_base:");
+			dump(dest_ref[i], 25);
+			printf("dprod_dut:");
+			dump(dest_ptrs[i], 25);
+			return -1;
+		}
+	}
+
+	putchar('.');
+
+	// Rand data test
+
+	for (rtest = 0; rtest < RANDOMS; rtest++) {
+		for (i = 0; i < TEST_SOURCES; i++)
+			for (j = 0; j < TEST_LEN; j++)
+				buffs[i][j] = rand();
+
+		for (i = 0; i < vector; i++)
+			for (j = 0; j < TEST_SOURCES; j++) {
+				gf[i][j] = rand();
+				gf_vect_mul_init(gf[i][j],
+						 &g_tbls[i * (32 * TEST_SOURCES) + j * 32]);
+			}
+
+		for (i = 0; i < vector; i++)
+			gf_vect_dot_prod_base(TEST_LEN, TEST_SOURCES,
+					      &g_tbls[i * 32 * TEST_SOURCES], buffs,
+					      dest_ref[i]);
+
+		for (i = 0; i < vector; i++)
+			memset(dest_ptrs[i], 0, TEST_LEN);
+		for (i = 0; i < TEST_SOURCES; i++) {
+#if (VECT == 1)
+			FUNCTION_UNDER_TEST(TEST_LEN, TEST_SOURCES, i, g_tbls, buffs[i],
+					    *dest_ptrs);
+#else
+			FUNCTION_UNDER_TEST(TEST_LEN, TEST_SOURCES, i, g_tbls, buffs[i],
+					    dest_ptrs);
+#endif
+		}
+		for (i = 0; i < vector; i++) {
+			if (0 != memcmp(dest_ref[i], dest_ptrs[i], TEST_LEN)) {
+				printf("Fail rand " xstr(FUNCTION_UNDER_TEST) " test%d %d\n",
+				       i, rtest);
+				dump_matrix(buffs, vector, TEST_SOURCES);
+				printf("dprod_base:");
+				dump(dest_ref[i], 25);
+				printf("dprod_dut:");
+				dump(dest_ptrs[i], 25);
+				return -1;
+			}
+		}
+
+		putchar('.');
+	}
+
+	// Rand data test with varied parameters
+	for (rtest = 0; rtest < RANDOMS; rtest++) {
+		for (srcs = TEST_SOURCES; srcs > 0; srcs--) {
+			for (i = 0; i < srcs; i++)
+				for (j = 0; j < TEST_LEN; j++)
+					buffs[i][j] = rand();
+
+			for (i = 0; i < vector; i++)
+				for (j = 0; j < srcs; j++) {
+					gf[i][j] = rand();
+					gf_vect_mul_init(gf[i][j],
+							 &g_tbls[i * (32 * srcs) + j * 32]);
+				}
+
+			for (i = 0; i < vector; i++)
+				gf_vect_dot_prod_base(TEST_LEN, srcs, &g_tbls[i * 32 * srcs],
+						      buffs, dest_ref[i]);
+
+			for (i = 0; i < vector; i++)
+				memset(dest_ptrs[i], 0, TEST_LEN);
+			for (i = 0; i < srcs; i++) {
+#if (VECT == 1)
+				FUNCTION_UNDER_TEST(TEST_LEN, srcs, i, g_tbls, buffs[i],
+						    *dest_ptrs);
+#else
+				FUNCTION_UNDER_TEST(TEST_LEN, srcs, i, g_tbls, buffs[i],
+						    dest_ptrs);
+#endif
+
+			}
+			for (i = 0; i < vector; i++) {
+				if (0 != memcmp(dest_ref[i], dest_ptrs[i], TEST_LEN)) {
+					printf("Fail rand " xstr(FUNCTION_UNDER_TEST)
+					       " test%d srcs=%d\n", i, srcs);
+					dump_matrix(buffs, vector, TEST_SOURCES);
+					printf("dprod_base:");
+					dump(dest_ref[i], 25);
+					printf("dprod_dut:");
+					dump(dest_ptrs[i], 25);
+					return -1;
+				}
+			}
+
+			putchar('.');
+		}
+	}
+
+	// Run tests at end of buffer for Electric Fence
+	align = (LEN_ALIGN_CHK_B != 0) ? 1 : ALIGN_SIZE;
+	for (size = TEST_MIN_SIZE; size <= TEST_SIZE; size += align) {
+		for (i = 0; i < TEST_SOURCES; i++)
+			for (j = 0; j < TEST_LEN; j++)
+				buffs[i][j] = rand();
+
+		for (i = 0; i < TEST_SOURCES; i++)	// Line up TEST_SIZE from end
+			efence_buffs[i] = buffs[i] + TEST_LEN - size;
+
+		for (i = 0; i < vector; i++)
+			for (j = 0; j < TEST_SOURCES; j++) {
+				gf[i][j] = rand();
+				gf_vect_mul_init(gf[i][j],
+						 &g_tbls[i * (32 * TEST_SOURCES) + j * 32]);
+			}
+
+		for (i = 0; i < vector; i++)
+			gf_vect_dot_prod_base(size, TEST_SOURCES,
+					      &g_tbls[i * 32 * TEST_SOURCES], efence_buffs,
+					      dest_ref[i]);
+
+		for (i = 0; i < vector; i++)
+			memset(dest_ptrs[i], 0, size);
+		for (i = 0; i < TEST_SOURCES; i++) {
+#if (VECT == 1)
+			FUNCTION_UNDER_TEST(size, TEST_SOURCES, i, g_tbls, efence_buffs[i],
+					    *dest_ptrs);
+#else
+			FUNCTION_UNDER_TEST(size, TEST_SOURCES, i, g_tbls, efence_buffs[i],
+					    dest_ptrs);
+#endif
+		}
+		for (i = 0; i < vector; i++) {
+			if (0 != memcmp(dest_ref[i], dest_ptrs[i], size)) {
+				printf("Fail rand " xstr(FUNCTION_UNDER_TEST)
+				       " test%d size=%d\n", i, size);
+				dump_matrix(buffs, vector, TEST_SOURCES);
+				printf("dprod_base:");
+				dump(dest_ref[i], TEST_MIN_SIZE + align);
+				printf("dprod_dut:");
+				dump(dest_ptrs[i], TEST_MIN_SIZE + align);
+				return -1;
+			}
+		}
+
+		putchar('.');
+	}
+
+	// Test rand ptr alignment if available
+
+	for (rtest = 0; rtest < RANDOMS; rtest++) {
+		size = (TEST_LEN - PTR_ALIGN_CHK_B) & ~(TEST_MIN_SIZE - 1);
+		srcs = rand() % TEST_SOURCES;
+		if (srcs == 0)
+			continue;
+
+		offset = (PTR_ALIGN_CHK_B != 0) ? 1 : PTR_ALIGN_CHK_B;
+		// Add random offsets
+		for (i = 0; i < srcs; i++)
+			ubuffs[i] = buffs[i] + (rand() & (PTR_ALIGN_CHK_B - offset));
+
+		for (i = 0; i < vector; i++) {
+			udest_ptrs[i] = dest_ptrs[i] + (rand() & (PTR_ALIGN_CHK_B - offset));
+			memset(dest_ptrs[i], 0, TEST_LEN);	// zero pad to check write-over
+		}
+
+		for (i = 0; i < srcs; i++)
+			for (j = 0; j < size; j++)
+				ubuffs[i][j] = rand();
+
+		for (i = 0; i < vector; i++)
+			for (j = 0; j < srcs; j++) {
+				gf[i][j] = rand();
+				gf_vect_mul_init(gf[i][j], &g_tbls[i * (32 * srcs) + j * 32]);
+			}
+
+		for (i = 0; i < vector; i++)
+			gf_vect_dot_prod_base(size, srcs, &g_tbls[i * 32 * srcs], ubuffs,
+					      dest_ref[i]);
+
+		for (i = 0; i < srcs; i++) {
+#if (VECT == 1)
+			FUNCTION_UNDER_TEST(size, srcs, i, g_tbls, ubuffs[i], *udest_ptrs);
+#else
+			FUNCTION_UNDER_TEST(size, srcs, i, g_tbls, ubuffs[i], udest_ptrs);
+#endif
+		}
+		for (i = 0; i < vector; i++) {
+			if (0 != memcmp(dest_ref[i], udest_ptrs[i], size)) {
+				printf("Fail rand " xstr(FUNCTION_UNDER_TEST)
+				       " test%d ualign srcs=%d\n", i, srcs);
+				dump_matrix(buffs, vector, TEST_SOURCES);
+				printf("dprod_base:");
+				dump(dest_ref[i], 25);
+				printf("dprod_dut:");
+				dump(udest_ptrs[i], 25);
+				return -1;
+			}
+		}
+
+		// Confirm that padding around dests is unchanged
+		memset(dest_ref[0], 0, PTR_ALIGN_CHK_B);	// Make reference zero buff
+
+		for (i = 0; i < vector; i++) {
+			offset = udest_ptrs[i] - dest_ptrs[i];
+			if (memcmp(dest_ptrs[i], dest_ref[0], offset)) {
+				printf("Fail rand ualign pad1 start\n");
+				return -1;
+			}
+			if (memcmp
+			    (dest_ptrs[i] + offset + size, dest_ref[0],
+			     PTR_ALIGN_CHK_B - offset)) {
+				printf("Fail rand ualign pad1 end\n");
+				return -1;
+			}
+		}
+
+		putchar('.');
+	}
+
+	// Test all size alignment
+	align = (LEN_ALIGN_CHK_B != 0) ? 1 : ALIGN_SIZE;
+
+	for (size = TEST_LEN; size >= TEST_MIN_SIZE; size -= align) {
+		for (i = 0; i < TEST_SOURCES; i++)
+			for (j = 0; j < size; j++)
+				buffs[i][j] = rand();
+
+		for (i = 0; i < vector; i++) {
+			for (j = 0; j < TEST_SOURCES; j++) {
+				gf[i][j] = rand();
+				gf_vect_mul_init(gf[i][j],
+						 &g_tbls[i * (32 * TEST_SOURCES) + j * 32]);
+			}
+			memset(dest_ptrs[i], 0, TEST_LEN);	// zero pad to check write-over
+		}
+
+		for (i = 0; i < vector; i++)
+			gf_vect_dot_prod_base(size, TEST_SOURCES,
+					      &g_tbls[i * 32 * TEST_SOURCES], buffs,
+					      dest_ref[i]);
+
+		for (i = 0; i < TEST_SOURCES; i++) {
+#if (VECT == 1)
+			FUNCTION_UNDER_TEST(size, TEST_SOURCES, i, g_tbls, buffs[i],
+					    *dest_ptrs);
+#else
+			FUNCTION_UNDER_TEST(size, TEST_SOURCES, i, g_tbls, buffs[i],
+					    dest_ptrs);
+#endif
+		}
+		for (i = 0; i < vector; i++) {
+			if (0 != memcmp(dest_ref[i], dest_ptrs[i], size)) {
+				printf("Fail rand " xstr(FUNCTION_UNDER_TEST)
+				       " test%d ualign len=%d\n", i, size);
+				dump_matrix(buffs, vector, TEST_SOURCES);
+				printf("dprod_base:");
+				dump(dest_ref[i], 25);
+				printf("dprod_dut:");
+				dump(dest_ptrs[i], 25);
+				return -1;
+			}
+		}
+
+		putchar('.');
+
+	}
+
+	printf("Pass\n");
+	return 0;
+
+}

--- a/erasure_code/loongarch64/gf_vect_dot_prod_lasx.c
+++ b/erasure_code/loongarch64/gf_vect_dot_prod_lasx.c
@@ -1,0 +1,138 @@
+/**********************************************************************
+  Copyright(c) 2022 Loongson Tech All rights reserved.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions
+  are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in
+      the documentation and/or other materials provided with the
+      distribution.
+    * Neither the name of Intel Corporation nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+**********************************************************************/
+
+#include <lasxintrin.h>
+
+void gf_vect_dot_prod_lasx(int len, int vlen, unsigned char *gftbls,
+			   unsigned char **src, unsigned char *dest)
+{
+	int i, j;
+
+	int block_count = len >> 5;
+	int remain = len - (block_count << 5);
+	int offset = 0;
+
+	__m256i block, high_idx, low_idx;
+	__m256i high_elem, low_elem;
+       	__m256i	high_val, low_val;
+	__m256i res;
+
+	unsigned long sul, index, tmp;
+	unsigned char *pos;
+	unsigned char suc, sval;
+
+	for (i = 0; i < block_count; ++i) {
+		res = __lasx_xvldi(0);
+
+		offset = i << 5;
+		for (j = 0; j < vlen; ++j) {
+			/* read one block from one buf to update one row */
+
+			// fetch one block from one buf into a vector variable,
+			// the block size is 32 bytes
+			block = __lasx_xvldx(src[j], offset);
+
+			// get low indexes
+			low_idx = __lasx_xvandi_b(block, 0x0F);
+
+			// get high indexes: shift right 4 bits and add 0x10,
+			// which can index {0x10, ..., 0x1F}
+			high_idx = __lasx_xvori_b(__lasx_xvsrli_b(block, 4), 0x10);
+
+			/* =================== for row 0 =================== */
+			// fetch one element from gftbls, which is 32 bytes
+			low_elem = __lasx_xvldx(gftbls, j << 5);
+			high_elem = low_elem;
+
+			// duplicate low part
+			low_elem = __lasx_xvpermi_d(low_elem, 0x44);
+
+			// duplicate high part
+			high_elem = __lasx_xvpermi_d(high_elem, 0xEE);
+
+			// pick by low_idx
+			low_val = __lasx_xvshuf_b(low_elem, low_elem, low_idx);
+
+			// pick by high_idx
+			high_val = __lasx_xvshuf_b(high_elem, high_elem, high_idx);
+
+			// accumulation on GF(2^8)
+			res = __lasx_xvxor_v(res, __lasx_xvxor_v(low_val, high_val));
+		}
+
+		__lasx_xvstx(res, dest, offset);
+	}
+
+	if (remain == 0)
+		return;
+
+	// handle remain bytes
+	i = block_count << 5;
+	while (remain >= 8) {
+		sul = 0;
+		for (j = 0; j < vlen; ++j) {
+			index = *(unsigned long *)&src[j][i];
+			pos = &gftbls[(j << 5)];
+
+			tmp = pos[index & 0xF] ^ pos[16 + ((index >> 4) & 0xF)];
+			index = index >> 8;
+			tmp |= (unsigned long)(pos[index & 0xF] ^ pos[16 + ((index >> 4) & 0xF)]) << 8;
+			index = index >> 8;
+			tmp |= (unsigned long)(pos[index & 0xF] ^ pos[16 + ((index >> 4) & 0xF)]) << 16;
+			index = index >> 8;
+			tmp |= (unsigned long)(pos[index & 0xF] ^ pos[16 + ((index >> 4) & 0xF)]) << 24;
+			index = index >> 8;
+			tmp |= (unsigned long)(pos[index & 0xF] ^ pos[16 + ((index >> 4) & 0xF)]) << 32;
+			index = index >> 8;
+			tmp |= (unsigned long)(pos[index & 0xF] ^ pos[16 + ((index >> 4) & 0xF)]) << 40;
+			index = index >> 8;
+			tmp |= (unsigned long)(pos[index & 0xF] ^ pos[16 + ((index >> 4) & 0xF)]) << 48;
+			index = index >> 8;
+			tmp |= (unsigned long)(pos[index & 0xF] ^ pos[16 + ((index >> 4) & 0xF)]) << 56;
+
+			sul ^= tmp;
+		}
+		*(unsigned long *)&dest[i] = sul;
+		i += sizeof(unsigned long);
+		remain -= sizeof(unsigned long);
+	}
+
+	if (remain == 0)
+		return;
+
+	for (; i < len; i++) {
+		suc = 0;
+		for (j = 0; j < vlen; j++) {
+			sval = src[j][i];
+			pos = &gftbls[(j << 5)];
+			suc ^= pos[sval & 0xF] ^ pos[16 + (sval >> 4)];
+		}
+		dest[i] = suc;
+	}
+}

--- a/erasure_code/loongarch64/gf_vect_dot_prod_lasx_test.c
+++ b/erasure_code/loongarch64/gf_vect_dot_prod_lasx_test.c
@@ -1,0 +1,526 @@
+/**********************************************************************
+  Copyright(c) 2011-2015 Intel Corporation All rights reserved.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions
+  are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in
+      the documentation and/or other materials provided with the
+      distribution.
+    * Neither the name of Intel Corporation nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+**********************************************************************/
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>		// for memset, memcmp
+#include "erasure_code.h"
+#include "ec_loongarch64.h"
+#include "types.h"
+
+#ifndef FUNCTION_UNDER_TEST
+# define FUNCTION_UNDER_TEST gf_vect_dot_prod_lasx
+#endif
+#ifndef TEST_MIN_SIZE
+# define TEST_MIN_SIZE  32
+#endif
+
+#define str(s) #s
+#define xstr(s) str(s)
+
+#define TEST_LEN (8192+31)
+#define TEST_SIZE (TEST_LEN/2)
+
+#ifndef TEST_SOURCES
+# define TEST_SOURCES  16
+#endif
+#ifndef RANDOMS
+# define RANDOMS 20
+#endif
+
+#define MMAX TEST_SOURCES
+#define KMAX TEST_SOURCES
+
+#ifdef EC_ALIGNED_ADDR
+// Define power of 2 range to check ptr, len alignment
+# define PTR_ALIGN_CHK_B 0
+# define LEN_ALIGN_CHK_B 0	// 0 for aligned only
+#else
+// Define power of 2 range to check ptr, len alignment
+# define PTR_ALIGN_CHK_B 32
+# define LEN_ALIGN_CHK_B 32	// 0 for aligned only
+#endif
+
+typedef unsigned char u8;
+
+void dump(unsigned char *buf, int len)
+{
+	int i;
+	for (i = 0; i < len;) {
+		printf(" %2x", 0xff & buf[i++]);
+		if (i % 32 == 0)
+			printf("\n");
+	}
+	printf("\n");
+}
+
+void dump_matrix(unsigned char **s, int k, int m)
+{
+	int i, j;
+	for (i = 0; i < k; i++) {
+		for (j = 0; j < m; j++) {
+			printf(" %2x", s[i][j]);
+		}
+		printf("\n");
+	}
+	printf("\n");
+}
+
+void dump_u8xu8(unsigned char *s, int k, int m)
+{
+	int i, j;
+	for (i = 0; i < k; i++) {
+		for (j = 0; j < m; j++) {
+			printf(" %2x", 0xff & s[j + (i * m)]);
+		}
+		printf("\n");
+	}
+	printf("\n");
+}
+
+int main(int argc, char *argv[])
+{
+	int i, j, rtest, srcs, m, k, nerrs, r, err;
+	void *buf;
+	u8 g[TEST_SOURCES], g_tbls[TEST_SOURCES * 32], src_in_err[TEST_SOURCES];
+	u8 *dest, *dest_ref, *temp_buff, *buffs[TEST_SOURCES];
+	u8 a[MMAX * KMAX], b[MMAX * KMAX], d[MMAX * KMAX];
+	u8 src_err_list[TEST_SOURCES], *recov[TEST_SOURCES];
+
+	int align, size;
+	unsigned char *efence_buffs[TEST_SOURCES];
+	unsigned int offset;
+	u8 *ubuffs[TEST_SOURCES];
+	u8 *udest_ptr;
+
+	printf(xstr(FUNCTION_UNDER_TEST) ": %dx%d ", TEST_SOURCES, TEST_LEN);
+
+	// Allocate the arrays
+	for (i = 0; i < TEST_SOURCES; i++) {
+		if (posix_memalign(&buf, 64, TEST_LEN)) {
+			printf("alloc error: Fail");
+			return -1;
+		}
+		buffs[i] = buf;
+	}
+
+	if (posix_memalign(&buf, 64, TEST_LEN)) {
+		printf("alloc error: Fail");
+		return -1;
+	}
+	dest = buf;
+
+	if (posix_memalign(&buf, 64, TEST_LEN)) {
+		printf("alloc error: Fail");
+		return -1;
+	}
+	dest_ref = buf;
+
+	if (posix_memalign(&buf, 64, TEST_LEN)) {
+		printf("alloc error: Fail");
+		return -1;
+	}
+	temp_buff = buf;
+
+	// Test of all zeros
+	for (i = 0; i < TEST_SOURCES; i++)
+		memset(buffs[i], 0, TEST_LEN);
+
+	memset(dest, 0, TEST_LEN);
+	memset(temp_buff, 0, TEST_LEN);
+	memset(dest_ref, 0, TEST_LEN);
+	memset(g, 0, TEST_SOURCES);
+
+	for (i = 0; i < TEST_SOURCES; i++)
+		gf_vect_mul_init(g[i], &g_tbls[i * 32]);
+
+	gf_vect_dot_prod_base(TEST_LEN, TEST_SOURCES, &g_tbls[0], buffs, dest_ref);
+
+	FUNCTION_UNDER_TEST(TEST_LEN, TEST_SOURCES, g_tbls, buffs, dest);
+
+	if (0 != memcmp(dest_ref, dest, TEST_LEN)) {
+		printf("Fail zero " xstr(FUNCTION_UNDER_TEST) " \n");
+		dump_matrix(buffs, 5, TEST_SOURCES);
+		printf("dprod_base:");
+		dump(dest_ref, 25);
+		printf("dprod:");
+		dump(dest, 25);
+		return -1;
+	} else
+		putchar('.');
+
+	// Rand data test
+	for (rtest = 0; rtest < RANDOMS; rtest++) {
+		for (i = 0; i < TEST_SOURCES; i++)
+			for (j = 0; j < TEST_LEN; j++)
+				buffs[i][j] = rand();
+
+		for (i = 0; i < TEST_SOURCES; i++)
+			g[i] = rand();
+
+		for (i = 0; i < TEST_SOURCES; i++)
+			gf_vect_mul_init(g[i], &g_tbls[i * 32]);
+
+		gf_vect_dot_prod_base(TEST_LEN, TEST_SOURCES, &g_tbls[0], buffs, dest_ref);
+		FUNCTION_UNDER_TEST(TEST_LEN, TEST_SOURCES, g_tbls, buffs, dest);
+
+		if (0 != memcmp(dest_ref, dest, TEST_LEN)) {
+			printf("Fail rand " xstr(FUNCTION_UNDER_TEST) " 1\n");
+			dump_matrix(buffs, 5, TEST_SOURCES);
+			printf("dprod_base:");
+			dump(dest_ref, 25);
+			printf("dprod:");
+			dump(dest, 25);
+			return -1;
+		}
+
+		putchar('.');
+	}
+
+	// Rand data test with varied parameters
+	for (rtest = 0; rtest < RANDOMS; rtest++) {
+		for (srcs = TEST_SOURCES; srcs > 0; srcs--) {
+			for (i = 0; i < srcs; i++)
+				for (j = 0; j < TEST_LEN; j++)
+					buffs[i][j] = rand();
+
+			for (i = 0; i < srcs; i++)
+				g[i] = rand();
+
+			for (i = 0; i < srcs; i++)
+				gf_vect_mul_init(g[i], &g_tbls[i * 32]);
+
+			gf_vect_dot_prod_base(TEST_LEN, srcs, &g_tbls[0], buffs, dest_ref);
+			FUNCTION_UNDER_TEST(TEST_LEN, srcs, g_tbls, buffs, dest);
+
+			if (0 != memcmp(dest_ref, dest, TEST_LEN)) {
+				printf("Fail rand " xstr(FUNCTION_UNDER_TEST) " test 2\n");
+				dump_matrix(buffs, 5, srcs);
+				printf("dprod_base:");
+				dump(dest_ref, 5);
+				printf("dprod:");
+				dump(dest, 5);
+				return -1;
+			}
+
+			putchar('.');
+		}
+	}
+
+	// Test erasure code using gf_vect_dot_prod
+
+	// Pick a first test
+	m = 9;
+	k = 5;
+	if (m > MMAX || k > KMAX)
+		return -1;
+
+	gf_gen_rs_matrix(a, m, k);
+
+	// Make random data
+	for (i = 0; i < k; i++)
+		for (j = 0; j < TEST_LEN; j++)
+			buffs[i][j] = rand();
+
+	// Make parity vects
+	for (i = k; i < m; i++) {
+		for (j = 0; j < k; j++)
+			gf_vect_mul_init(a[k * i + j], &g_tbls[j * 32]);
+#ifndef USEREF
+		FUNCTION_UNDER_TEST(TEST_LEN, k, g_tbls, buffs, buffs[i]);
+#else
+		gf_vect_dot_prod_base(TEST_LEN, k, &g_tbls[0], buffs, buffs[i]);
+#endif
+	}
+
+	// Random buffers in erasure
+	memset(src_in_err, 0, TEST_SOURCES);
+	for (i = 0, nerrs = 0; i < k && nerrs < m - k; i++) {
+		err = 1 & rand();
+		src_in_err[i] = err;
+		if (err)
+			src_err_list[nerrs++] = i;
+	}
+
+	// construct b by removing error rows
+	for (i = 0, r = 0; i < k; i++, r++) {
+		while (src_in_err[r]) {
+			r++;
+			continue;
+		}
+		for (j = 0; j < k; j++)
+			b[k * i + j] = a[k * r + j];
+	}
+
+	if (gf_invert_matrix((u8 *) b, (u8 *) d, k) < 0)
+		printf("BAD MATRIX\n");
+
+	for (i = 0, r = 0; i < k; i++, r++) {
+		while (src_in_err[r]) {
+			r++;
+			continue;
+		}
+		recov[i] = buffs[r];
+	}
+
+	// Recover data
+	for (i = 0; i < nerrs; i++) {
+		for (j = 0; j < k; j++)
+			gf_vect_mul_init(d[k * src_err_list[i] + j], &g_tbls[j * 32]);
+#ifndef USEREF
+		FUNCTION_UNDER_TEST(TEST_LEN, k, g_tbls, recov, temp_buff);
+#else
+		gf_vect_dot_prod_base(TEST_LEN, k, &g_tbls[0], recov, temp_buff);
+#endif
+
+		if (0 != memcmp(temp_buff, buffs[src_err_list[i]], TEST_LEN)) {
+			printf("Fail error recovery (%d, %d, %d)\n", m, k, nerrs);
+			printf("recov %d:", src_err_list[i]);
+			dump(temp_buff, 25);
+			printf("orig   :");
+			dump(buffs[src_err_list[i]], 25);
+			return -1;
+		}
+	}
+
+	// Do more random tests
+
+	for (rtest = 0; rtest < RANDOMS; rtest++) {
+		while ((m = (rand() % MMAX)) < 2) ;
+		while ((k = (rand() % KMAX)) >= m || k < 1) ;
+
+		if (m > MMAX || k > KMAX)
+			continue;
+
+		gf_gen_rs_matrix(a, m, k);
+
+		// Make random data
+		for (i = 0; i < k; i++)
+			for (j = 0; j < TEST_LEN; j++)
+				buffs[i][j] = rand();
+
+		// Make parity vects
+		for (i = k; i < m; i++) {
+			for (j = 0; j < k; j++)
+				gf_vect_mul_init(a[k * i + j], &g_tbls[j * 32]);
+#ifndef USEREF
+			FUNCTION_UNDER_TEST(TEST_LEN, k, g_tbls, buffs, buffs[i]);
+#else
+			gf_vect_dot_prod_base(TEST_LEN, k, &g_tbls[0], buffs, buffs[i]);
+#endif
+		}
+
+		// Random errors
+		memset(src_in_err, 0, TEST_SOURCES);
+		for (i = 0, nerrs = 0; i < k && nerrs < m - k; i++) {
+			err = 1 & rand();
+			src_in_err[i] = err;
+			if (err)
+				src_err_list[nerrs++] = i;
+		}
+		if (nerrs == 0) {	// should have at least one error
+			while ((err = (rand() % KMAX)) >= k) ;
+			src_err_list[nerrs++] = err;
+			src_in_err[err] = 1;
+		}
+		// construct b by removing error rows
+		for (i = 0, r = 0; i < k; i++, r++) {
+			while (src_in_err[r]) {
+				r++;
+				continue;
+			}
+			for (j = 0; j < k; j++)
+				b[k * i + j] = a[k * r + j];
+		}
+
+		if (gf_invert_matrix((u8 *) b, (u8 *) d, k) < 0)
+			printf("BAD MATRIX\n");
+
+		for (i = 0, r = 0; i < k; i++, r++) {
+			while (src_in_err[r]) {
+				r++;
+				continue;
+			}
+			recov[i] = buffs[r];
+		}
+
+		// Recover data
+		for (i = 0; i < nerrs; i++) {
+			for (j = 0; j < k; j++)
+				gf_vect_mul_init(d[k * src_err_list[i] + j], &g_tbls[j * 32]);
+#ifndef USEREF
+			FUNCTION_UNDER_TEST(TEST_LEN, k, g_tbls, recov, temp_buff);
+#else
+			gf_vect_dot_prod_base(TEST_LEN, k, &g_tbls[0], recov, temp_buff);
+#endif
+			if (0 != memcmp(temp_buff, buffs[src_err_list[i]], TEST_LEN)) {
+				printf("Fail error recovery (%d, %d, %d) - ", m, k, nerrs);
+				printf(" - erase list = ");
+				for (i = 0; i < nerrs; i++)
+					printf(" %d", src_err_list[i]);
+				printf("\na:\n");
+				dump_u8xu8((u8 *) a, m, k);
+				printf("inv b:\n");
+				dump_u8xu8((u8 *) d, k, k);
+				printf("orig data:\n");
+				dump_matrix(buffs, m, 25);
+				printf("orig   :");
+				dump(buffs[src_err_list[i]], 25);
+				printf("recov %d:", src_err_list[i]);
+				dump(temp_buff, 25);
+				return -1;
+			}
+		}
+		putchar('.');
+	}
+
+	// Run tests at end of buffer for Electric Fence
+	align = (LEN_ALIGN_CHK_B != 0) ? 1 : 16;
+	for (size = TEST_MIN_SIZE; size <= TEST_SIZE; size += align) {
+		for (i = 0; i < TEST_SOURCES; i++)
+			for (j = 0; j < TEST_LEN; j++)
+				buffs[i][j] = rand();
+
+		for (i = 0; i < TEST_SOURCES; i++)	// Line up TEST_SIZE from end
+			efence_buffs[i] = buffs[i] + TEST_LEN - size;
+
+		for (i = 0; i < TEST_SOURCES; i++)
+			g[i] = rand();
+
+		for (i = 0; i < TEST_SOURCES; i++)
+			gf_vect_mul_init(g[i], &g_tbls[i * 32]);
+
+		gf_vect_dot_prod_base(size, TEST_SOURCES, &g_tbls[0], efence_buffs, dest_ref);
+		FUNCTION_UNDER_TEST(size, TEST_SOURCES, g_tbls, efence_buffs, dest);
+
+		if (0 != memcmp(dest_ref, dest, size)) {
+			printf("Fail rand " xstr(FUNCTION_UNDER_TEST) " test 3\n");
+			dump_matrix(efence_buffs, 5, TEST_SOURCES);
+			printf("dprod_base:");
+			dump(dest_ref, align);
+			printf("dprod:");
+			dump(dest, align);
+			return -1;
+		}
+
+		putchar('.');
+	}
+
+	// Test rand ptr alignment if available
+
+	for (rtest = 0; rtest < RANDOMS; rtest++) {
+		size = (TEST_LEN - PTR_ALIGN_CHK_B) & ~(TEST_MIN_SIZE - 1);
+		srcs = rand() % TEST_SOURCES;
+		if (srcs == 0)
+			continue;
+
+		offset = (PTR_ALIGN_CHK_B != 0) ? 1 : PTR_ALIGN_CHK_B;
+		// Add random offsets
+		for (i = 0; i < srcs; i++)
+			ubuffs[i] = buffs[i] + (rand() & (PTR_ALIGN_CHK_B - offset));
+
+		udest_ptr = dest + (rand() & (PTR_ALIGN_CHK_B - offset));
+
+		memset(dest, 0, TEST_LEN);	// zero pad to check write-over
+
+		for (i = 0; i < srcs; i++)
+			for (j = 0; j < size; j++)
+				ubuffs[i][j] = rand();
+
+		for (i = 0; i < srcs; i++)
+			g[i] = rand();
+
+		for (i = 0; i < srcs; i++)
+			gf_vect_mul_init(g[i], &g_tbls[i * 32]);
+
+		gf_vect_dot_prod_base(size, srcs, &g_tbls[0], ubuffs, dest_ref);
+
+		FUNCTION_UNDER_TEST(size, srcs, g_tbls, ubuffs, udest_ptr);
+
+		if (memcmp(dest_ref, udest_ptr, size)) {
+			printf("Fail rand " xstr(FUNCTION_UNDER_TEST) " ualign srcs=%d\n",
+			       srcs);
+			dump_matrix(ubuffs, 5, TEST_SOURCES);
+			printf("dprod_base:");
+			dump(dest_ref, 25);
+			printf("dprod:");
+			dump(udest_ptr, 25);
+			return -1;
+		}
+		// Confirm that padding around dests is unchanged
+		memset(dest_ref, 0, PTR_ALIGN_CHK_B);	// Make reference zero buff
+		offset = udest_ptr - dest;
+
+		if (memcmp(dest, dest_ref, offset)) {
+			printf("Fail rand ualign pad start\n");
+			return -1;
+		}
+		if (memcmp(dest + offset + size, dest_ref, PTR_ALIGN_CHK_B - offset)) {
+			printf("Fail rand ualign pad end\n");
+			return -1;
+		}
+
+		putchar('.');
+	}
+
+	// Test all size alignment
+	align = (LEN_ALIGN_CHK_B != 0) ? 1 : 16;
+
+	for (size = TEST_LEN; size >= TEST_MIN_SIZE; size -= align) {
+		srcs = TEST_SOURCES;
+
+		for (i = 0; i < srcs; i++)
+			for (j = 0; j < size; j++)
+				buffs[i][j] = rand();
+
+		for (i = 0; i < srcs; i++)
+			g[i] = rand();
+
+		for (i = 0; i < srcs; i++)
+			gf_vect_mul_init(g[i], &g_tbls[i * 32]);
+
+		gf_vect_dot_prod_base(size, srcs, &g_tbls[0], buffs, dest_ref);
+
+		FUNCTION_UNDER_TEST(size, srcs, g_tbls, buffs, dest);
+
+		if (memcmp(dest_ref, dest, size)) {
+			printf("Fail rand " xstr(FUNCTION_UNDER_TEST) " ualign len=%d\n",
+			       size);
+			dump_matrix(buffs, 5, TEST_SOURCES);
+			printf("dprod_base:");
+			dump(dest_ref, 25);
+			printf("dprod:");
+			dump(dest, 25);
+			return -1;
+		}
+	}
+
+	printf("done all: Pass\n");
+	return 0;
+}

--- a/erasure_code/loongarch64/gf_vect_mad_lasx.c
+++ b/erasure_code/loongarch64/gf_vect_mad_lasx.c
@@ -1,0 +1,129 @@
+/**********************************************************************
+  Copyright(c) 2022 Loongson Tech All rights reserved.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions
+  are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in
+      the documentation and/or other materials provided with the
+      distribution.
+    * Neither the name of Intel Corporation nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+**********************************************************************/
+
+#include <lasxintrin.h>
+
+void gf_vect_mad_lasx(int len, int vec, int vec_i, unsigned char *gftbls,
+		      unsigned char *src, unsigned char *dest)
+{
+	int i;
+
+	int block_count = len >> 5;
+	int remain = len - (block_count << 5);
+	int buf_offset = 0;
+
+	__m256i block, high_idx, low_idx;
+	__m256i high_elem, low_elem;
+       	__m256i	high_val, low_val;
+	__m256i res;
+
+	unsigned long index, tmp;
+	unsigned char *pos = &gftbls[vec_i << 5];
+	unsigned char sval;
+
+	for (i = 0; i < block_count; ++i) {
+		/* read one block from src to update one row */
+
+		buf_offset = i << 5;
+		// fetch one block from one buf into a vector variable,
+		// the block size is 32 bytes
+		block = __lasx_xvldx(src, buf_offset);
+
+		// get low indexes
+		low_idx = __lasx_xvandi_b(block, 0x0F);
+
+		// get high indexes: shift right 4 bits and add 0x10,
+		// which can index {0x10, ..., 0x1F}
+		high_idx = __lasx_xvori_b(__lasx_xvsrli_b(block, 4), 0x10);
+
+		/* =================== for row 0 =================== */
+		// fetch one element from gftbls, which is 32 bytes
+		low_elem = __lasx_xvld(pos, 0);
+		high_elem = low_elem;
+
+		// duplicate low part
+		low_elem = __lasx_xvpermi_d(low_elem, 0x44);
+
+		// duplicate high part
+		high_elem = __lasx_xvpermi_d(high_elem, 0xEE);
+
+		// pick by low_idx
+		low_val = __lasx_xvshuf_b(low_elem, low_elem, low_idx);
+
+		// pick by high_idx
+		high_val = __lasx_xvshuf_b(high_elem, high_elem, high_idx);
+
+		// load old data
+		res = __lasx_xvldx(dest, buf_offset);
+
+		// accumulation on GF(2^8)
+		res = __lasx_xvxor_v(res, __lasx_xvxor_v(low_val, high_val));
+
+		// store new data
+		__lasx_xvstx(res, dest, buf_offset);
+	}
+
+	if (remain == 0)
+		return;
+
+	// handle remain bytes
+	i = block_count << 5;
+	while (remain >= 8) {
+		index = *(unsigned long *)&src[i];
+
+		tmp = pos[index & 0xF] ^ pos[16 + ((index >> 4) & 0xF)];
+		index = index >> 8;
+		tmp |= (unsigned long)(pos[index & 0xF] ^ pos[16 + ((index >> 4) & 0xF)]) << 8;
+		index = index >> 8;
+		tmp |= (unsigned long)(pos[index & 0xF] ^ pos[16 + ((index >> 4) & 0xF)]) << 16;
+		index = index >> 8;
+		tmp |= (unsigned long)(pos[index & 0xF] ^ pos[16 + ((index >> 4) & 0xF)]) << 24;
+		index = index >> 8;
+		tmp |= (unsigned long)(pos[index & 0xF] ^ pos[16 + ((index >> 4) & 0xF)]) << 32;
+		index = index >> 8;
+		tmp |= (unsigned long)(pos[index & 0xF] ^ pos[16 + ((index >> 4) & 0xF)]) << 40;
+		index = index >> 8;
+		tmp |= (unsigned long)(pos[index & 0xF] ^ pos[16 + ((index >> 4) & 0xF)]) << 48;
+		index = index >> 8;
+		tmp |= (unsigned long)(pos[index & 0xF] ^ pos[16 + ((index >> 4) & 0xF)]) << 56;
+
+		*(unsigned long *)&dest[i] ^= tmp;
+
+		i += sizeof(unsigned long);
+		remain -= sizeof(unsigned long);
+	}
+
+	if (remain == 0)
+		return;
+
+	for (; i < len; i++) {
+		sval = src[i];
+		dest[i] ^= pos[sval & 0xF] ^ pos[16 + (sval >> 4)];
+	}
+}

--- a/erasure_code/loongarch64/gf_vect_mad_lasx_test.c
+++ b/erasure_code/loongarch64/gf_vect_mad_lasx_test.c
@@ -1,0 +1,519 @@
+/**********************************************************************
+  Copyright(c) 2011-2015 Intel Corporation All rights reserved.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions
+  are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in
+      the documentation and/or other materials provided with the
+      distribution.
+    * Neither the name of Intel Corporation nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+**********************************************************************/
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>		// for memset, memcmp
+#include "erasure_code.h"
+#include "types.h"
+
+#ifndef ALIGN_SIZE
+# define ALIGN_SIZE 32
+#endif
+
+#ifndef FUNCTION_UNDER_TEST
+//By default, test multi-binary version
+# define FUNCTION_UNDER_TEST gf_vect_mad_lasx
+# define REF_FUNCTION gf_vect_dot_prod_lasx
+# define VECT 1
+#endif
+
+#ifndef TEST_MIN_SIZE
+# define TEST_MIN_SIZE 64
+#endif
+
+#define str(s) #s
+#define xstr(s) str(s)
+
+#define TEST_LEN (8192+31)
+#define TEST_SIZE (TEST_LEN/2)
+#define TEST_MEM  TEST_SIZE
+#define TEST_LOOPS 20000
+#define TEST_TYPE_STR ""
+
+#ifndef TEST_SOURCES
+# define TEST_SOURCES  16
+#endif
+#ifndef RANDOMS
+# define RANDOMS 20
+#endif
+
+#ifdef EC_ALIGNED_ADDR
+// Define power of 2 range to check ptr, len alignment
+# define PTR_ALIGN_CHK_B 0
+# define LEN_ALIGN_CHK_B 0	// 0 for aligned only
+#else
+// Define power of 2 range to check ptr, len alignment
+# define PTR_ALIGN_CHK_B ALIGN_SIZE
+# define LEN_ALIGN_CHK_B ALIGN_SIZE	// 0 for aligned only
+#endif
+
+#define str(s) #s
+#define xstr(s) str(s)
+
+typedef unsigned char u8;
+
+#if (VECT == 1)
+# define LAST_ARG *dest
+#else
+# define LAST_ARG **dest
+#endif
+
+extern void FUNCTION_UNDER_TEST(int len, int vec, int vec_i, unsigned char *gftbls,
+				unsigned char *src, unsigned char LAST_ARG);
+extern void REF_FUNCTION(int len, int vlen, unsigned char *gftbls, unsigned char **src,
+			 unsigned char LAST_ARG);
+
+void dump(unsigned char *buf, int len)
+{
+	int i;
+	for (i = 0; i < len;) {
+		printf(" %2x", 0xff & buf[i++]);
+		if (i % 32 == 0)
+			printf("\n");
+	}
+	printf("\n");
+}
+
+void dump_matrix(unsigned char **s, int k, int m)
+{
+	int i, j;
+	for (i = 0; i < k; i++) {
+		for (j = 0; j < m; j++) {
+			printf(" %2x", s[i][j]);
+		}
+		printf("\n");
+	}
+	printf("\n");
+}
+
+void dump_u8xu8(unsigned char *s, int k, int m)
+{
+	int i, j;
+	for (i = 0; i < k; i++) {
+		for (j = 0; j < m; j++) {
+			printf(" %2x", 0xff & s[j + (i * m)]);
+		}
+		printf("\n");
+	}
+	printf("\n");
+}
+
+int main(int argc, char *argv[])
+{
+	int i, j, rtest, srcs;
+	void *buf;
+	u8 gf[6][TEST_SOURCES];
+	u8 *g_tbls;
+	u8 *dest_ref[VECT];
+	u8 *dest_ptrs[VECT], *buffs[TEST_SOURCES];
+	int vector = VECT;
+
+	int align, size;
+	unsigned char *efence_buffs[TEST_SOURCES];
+	unsigned int offset;
+	u8 *ubuffs[TEST_SOURCES];
+	u8 *udest_ptrs[VECT];
+	printf("test" xstr(FUNCTION_UNDER_TEST) ": %dx%d ", TEST_SOURCES, TEST_LEN);
+
+	// Allocate the arrays
+	for (i = 0; i < TEST_SOURCES; i++) {
+		if (posix_memalign(&buf, 64, TEST_LEN)) {
+			printf("alloc error: Fail");
+			return -1;
+		}
+		buffs[i] = buf;
+	}
+
+	if (posix_memalign(&buf, 16, 2 * (vector * TEST_SOURCES * 32))) {
+		printf("alloc error: Fail");
+		return -1;
+	}
+	g_tbls = buf;
+
+	for (i = 0; i < vector; i++) {
+		if (posix_memalign(&buf, 64, TEST_LEN)) {
+			printf("alloc error: Fail");
+			return -1;
+		}
+		dest_ptrs[i] = buf;
+		memset(dest_ptrs[i], 0, TEST_LEN);
+	}
+
+	for (i = 0; i < vector; i++) {
+		if (posix_memalign(&buf, 64, TEST_LEN)) {
+			printf("alloc error: Fail");
+			return -1;
+		}
+		dest_ref[i] = buf;
+		memset(dest_ref[i], 0, TEST_LEN);
+	}
+
+	// Test of all zeros
+	for (i = 0; i < TEST_SOURCES; i++)
+		memset(buffs[i], 0, TEST_LEN);
+
+	switch (vector) {
+	case 6:
+		memset(gf[5], 0xe6, TEST_SOURCES);
+	case 5:
+		memset(gf[4], 4, TEST_SOURCES);
+	case 4:
+		memset(gf[3], 9, TEST_SOURCES);
+	case 3:
+		memset(gf[2], 7, TEST_SOURCES);
+	case 2:
+		memset(gf[1], 1, TEST_SOURCES);
+	case 1:
+		memset(gf[0], 2, TEST_SOURCES);
+		break;
+	default:
+		return -1;
+	}
+
+	for (i = 0; i < TEST_SOURCES; i++)
+		for (j = 0; j < TEST_LEN; j++)
+			buffs[i][j] = rand();
+
+	for (i = 0; i < vector; i++)
+		for (j = 0; j < TEST_SOURCES; j++) {
+			gf[i][j] = rand();
+			gf_vect_mul_init(gf[i][j], &g_tbls[i * (32 * TEST_SOURCES) + j * 32]);
+		}
+
+	for (i = 0; i < vector; i++)
+		gf_vect_dot_prod_base(TEST_LEN, TEST_SOURCES, &g_tbls[i * 32 * TEST_SOURCES],
+				      buffs, dest_ref[i]);
+
+	for (i = 0; i < vector; i++)
+		memset(dest_ptrs[i], 0, TEST_LEN);
+	for (i = 0; i < TEST_SOURCES; i++) {
+#if (VECT == 1)
+		FUNCTION_UNDER_TEST(TEST_LEN, TEST_SOURCES, i, g_tbls, buffs[i], *dest_ptrs);
+#else
+		FUNCTION_UNDER_TEST(TEST_LEN, TEST_SOURCES, i, g_tbls, buffs[i], dest_ptrs);
+#endif
+	}
+	for (i = 0; i < vector; i++) {
+		if (0 != memcmp(dest_ref[i], dest_ptrs[i], TEST_LEN)) {
+			printf("Fail zero " xstr(FUNCTION_UNDER_TEST) " test%d\n", i);
+			dump_matrix(buffs, vector, TEST_SOURCES);
+			printf("dprod_base:");
+			dump(dest_ref[i], 25);
+			printf("dprod_dut:");
+			dump(dest_ptrs[i], 25);
+			return -1;
+		}
+	}
+
+#if (VECT == 1)
+	REF_FUNCTION(TEST_LEN, TEST_SOURCES, g_tbls, buffs, *dest_ref);
+#else
+	REF_FUNCTION(TEST_LEN, TEST_SOURCES, g_tbls, buffs, dest_ref);
+#endif
+	for (i = 0; i < vector; i++) {
+		if (0 != memcmp(dest_ref[i], dest_ptrs[i], TEST_LEN)) {
+			printf("Fail zero " xstr(FUNCTION_UNDER_TEST) " test%d\n", i);
+			dump_matrix(buffs, vector, TEST_SOURCES);
+			printf("dprod_base:");
+			dump(dest_ref[i], 25);
+			printf("dprod_dut:");
+			dump(dest_ptrs[i], 25);
+			return -1;
+		}
+	}
+
+	putchar('.');
+
+	// Rand data test
+
+	for (rtest = 0; rtest < RANDOMS; rtest++) {
+		for (i = 0; i < TEST_SOURCES; i++)
+			for (j = 0; j < TEST_LEN; j++)
+				buffs[i][j] = rand();
+
+		for (i = 0; i < vector; i++)
+			for (j = 0; j < TEST_SOURCES; j++) {
+				gf[i][j] = rand();
+				gf_vect_mul_init(gf[i][j],
+						 &g_tbls[i * (32 * TEST_SOURCES) + j * 32]);
+			}
+
+		for (i = 0; i < vector; i++)
+			gf_vect_dot_prod_base(TEST_LEN, TEST_SOURCES,
+					      &g_tbls[i * 32 * TEST_SOURCES], buffs,
+					      dest_ref[i]);
+
+		for (i = 0; i < vector; i++)
+			memset(dest_ptrs[i], 0, TEST_LEN);
+		for (i = 0; i < TEST_SOURCES; i++) {
+#if (VECT == 1)
+			FUNCTION_UNDER_TEST(TEST_LEN, TEST_SOURCES, i, g_tbls, buffs[i],
+					    *dest_ptrs);
+#else
+			FUNCTION_UNDER_TEST(TEST_LEN, TEST_SOURCES, i, g_tbls, buffs[i],
+					    dest_ptrs);
+#endif
+		}
+		for (i = 0; i < vector; i++) {
+			if (0 != memcmp(dest_ref[i], dest_ptrs[i], TEST_LEN)) {
+				printf("Fail rand " xstr(FUNCTION_UNDER_TEST) " test%d %d\n",
+				       i, rtest);
+				dump_matrix(buffs, vector, TEST_SOURCES);
+				printf("dprod_base:");
+				dump(dest_ref[i], 25);
+				printf("dprod_dut:");
+				dump(dest_ptrs[i], 25);
+				return -1;
+			}
+		}
+
+		putchar('.');
+	}
+
+	// Rand data test with varied parameters
+	for (rtest = 0; rtest < RANDOMS; rtest++) {
+		for (srcs = TEST_SOURCES; srcs > 0; srcs--) {
+			for (i = 0; i < srcs; i++)
+				for (j = 0; j < TEST_LEN; j++)
+					buffs[i][j] = rand();
+
+			for (i = 0; i < vector; i++)
+				for (j = 0; j < srcs; j++) {
+					gf[i][j] = rand();
+					gf_vect_mul_init(gf[i][j],
+							 &g_tbls[i * (32 * srcs) + j * 32]);
+				}
+
+			for (i = 0; i < vector; i++)
+				gf_vect_dot_prod_base(TEST_LEN, srcs, &g_tbls[i * 32 * srcs],
+						      buffs, dest_ref[i]);
+
+			for (i = 0; i < vector; i++)
+				memset(dest_ptrs[i], 0, TEST_LEN);
+			for (i = 0; i < srcs; i++) {
+#if (VECT == 1)
+				FUNCTION_UNDER_TEST(TEST_LEN, srcs, i, g_tbls, buffs[i],
+						    *dest_ptrs);
+#else
+				FUNCTION_UNDER_TEST(TEST_LEN, srcs, i, g_tbls, buffs[i],
+						    dest_ptrs);
+#endif
+
+			}
+			for (i = 0; i < vector; i++) {
+				if (0 != memcmp(dest_ref[i], dest_ptrs[i], TEST_LEN)) {
+					printf("Fail rand " xstr(FUNCTION_UNDER_TEST)
+					       " test%d srcs=%d\n", i, srcs);
+					dump_matrix(buffs, vector, TEST_SOURCES);
+					printf("dprod_base:");
+					dump(dest_ref[i], 25);
+					printf("dprod_dut:");
+					dump(dest_ptrs[i], 25);
+					return -1;
+				}
+			}
+
+			putchar('.');
+		}
+	}
+
+	// Run tests at end of buffer for Electric Fence
+	align = (LEN_ALIGN_CHK_B != 0) ? 1 : ALIGN_SIZE;
+	for (size = TEST_MIN_SIZE; size <= TEST_SIZE; size += align) {
+		for (i = 0; i < TEST_SOURCES; i++)
+			for (j = 0; j < TEST_LEN; j++)
+				buffs[i][j] = rand();
+
+		for (i = 0; i < TEST_SOURCES; i++)	// Line up TEST_SIZE from end
+			efence_buffs[i] = buffs[i] + TEST_LEN - size;
+
+		for (i = 0; i < vector; i++)
+			for (j = 0; j < TEST_SOURCES; j++) {
+				gf[i][j] = rand();
+				gf_vect_mul_init(gf[i][j],
+						 &g_tbls[i * (32 * TEST_SOURCES) + j * 32]);
+			}
+
+		for (i = 0; i < vector; i++)
+			gf_vect_dot_prod_base(size, TEST_SOURCES,
+					      &g_tbls[i * 32 * TEST_SOURCES], efence_buffs,
+					      dest_ref[i]);
+
+		for (i = 0; i < vector; i++)
+			memset(dest_ptrs[i], 0, size);
+		for (i = 0; i < TEST_SOURCES; i++) {
+#if (VECT == 1)
+			FUNCTION_UNDER_TEST(size, TEST_SOURCES, i, g_tbls, efence_buffs[i],
+					    *dest_ptrs);
+#else
+			FUNCTION_UNDER_TEST(size, TEST_SOURCES, i, g_tbls, efence_buffs[i],
+					    dest_ptrs);
+#endif
+		}
+		for (i = 0; i < vector; i++) {
+			if (0 != memcmp(dest_ref[i], dest_ptrs[i], size)) {
+				printf("Fail rand " xstr(FUNCTION_UNDER_TEST)
+				       " test%d size=%d\n", i, size);
+				dump_matrix(buffs, vector, TEST_SOURCES);
+				printf("dprod_base:");
+				dump(dest_ref[i], TEST_MIN_SIZE + align);
+				printf("dprod_dut:");
+				dump(dest_ptrs[i], TEST_MIN_SIZE + align);
+				return -1;
+			}
+		}
+
+		putchar('.');
+	}
+
+	// Test rand ptr alignment if available
+
+	for (rtest = 0; rtest < RANDOMS; rtest++) {
+		size = (TEST_LEN - PTR_ALIGN_CHK_B) & ~(TEST_MIN_SIZE - 1);
+		srcs = rand() % TEST_SOURCES;
+		if (srcs == 0)
+			continue;
+
+		offset = (PTR_ALIGN_CHK_B != 0) ? 1 : PTR_ALIGN_CHK_B;
+		// Add random offsets
+		for (i = 0; i < srcs; i++)
+			ubuffs[i] = buffs[i] + (rand() & (PTR_ALIGN_CHK_B - offset));
+
+		for (i = 0; i < vector; i++) {
+			udest_ptrs[i] = dest_ptrs[i] + (rand() & (PTR_ALIGN_CHK_B - offset));
+			memset(dest_ptrs[i], 0, TEST_LEN);	// zero pad to check write-over
+		}
+
+		for (i = 0; i < srcs; i++)
+			for (j = 0; j < size; j++)
+				ubuffs[i][j] = rand();
+
+		for (i = 0; i < vector; i++)
+			for (j = 0; j < srcs; j++) {
+				gf[i][j] = rand();
+				gf_vect_mul_init(gf[i][j], &g_tbls[i * (32 * srcs) + j * 32]);
+			}
+
+		for (i = 0; i < vector; i++)
+			gf_vect_dot_prod_base(size, srcs, &g_tbls[i * 32 * srcs], ubuffs,
+					      dest_ref[i]);
+
+		for (i = 0; i < srcs; i++) {
+#if (VECT == 1)
+			FUNCTION_UNDER_TEST(size, srcs, i, g_tbls, ubuffs[i], *udest_ptrs);
+#else
+			FUNCTION_UNDER_TEST(size, srcs, i, g_tbls, ubuffs[i], udest_ptrs);
+#endif
+		}
+		for (i = 0; i < vector; i++) {
+			if (0 != memcmp(dest_ref[i], udest_ptrs[i], size)) {
+				printf("Fail rand " xstr(FUNCTION_UNDER_TEST)
+				       " test%d ualign srcs=%d\n", i, srcs);
+				dump_matrix(buffs, vector, TEST_SOURCES);
+				printf("dprod_base:");
+				dump(dest_ref[i], 25);
+				printf("dprod_dut:");
+				dump(udest_ptrs[i], 25);
+				return -1;
+			}
+		}
+
+		// Confirm that padding around dests is unchanged
+		memset(dest_ref[0], 0, PTR_ALIGN_CHK_B);	// Make reference zero buff
+
+		for (i = 0; i < vector; i++) {
+			offset = udest_ptrs[i] - dest_ptrs[i];
+			if (memcmp(dest_ptrs[i], dest_ref[0], offset)) {
+				printf("Fail rand ualign pad1 start\n");
+				return -1;
+			}
+			if (memcmp
+			    (dest_ptrs[i] + offset + size, dest_ref[0],
+			     PTR_ALIGN_CHK_B - offset)) {
+				printf("Fail rand ualign pad1 end\n");
+				return -1;
+			}
+		}
+
+		putchar('.');
+	}
+
+	// Test all size alignment
+	align = (LEN_ALIGN_CHK_B != 0) ? 1 : ALIGN_SIZE;
+
+	for (size = TEST_LEN; size >= TEST_MIN_SIZE; size -= align) {
+		for (i = 0; i < TEST_SOURCES; i++)
+			for (j = 0; j < size; j++)
+				buffs[i][j] = rand();
+
+		for (i = 0; i < vector; i++) {
+			for (j = 0; j < TEST_SOURCES; j++) {
+				gf[i][j] = rand();
+				gf_vect_mul_init(gf[i][j],
+						 &g_tbls[i * (32 * TEST_SOURCES) + j * 32]);
+			}
+			memset(dest_ptrs[i], 0, TEST_LEN);	// zero pad to check write-over
+		}
+
+		for (i = 0; i < vector; i++)
+			gf_vect_dot_prod_base(size, TEST_SOURCES,
+					      &g_tbls[i * 32 * TEST_SOURCES], buffs,
+					      dest_ref[i]);
+
+		for (i = 0; i < TEST_SOURCES; i++) {
+#if (VECT == 1)
+			FUNCTION_UNDER_TEST(size, TEST_SOURCES, i, g_tbls, buffs[i],
+					    *dest_ptrs);
+#else
+			FUNCTION_UNDER_TEST(size, TEST_SOURCES, i, g_tbls, buffs[i],
+					    dest_ptrs);
+#endif
+		}
+		for (i = 0; i < vector; i++) {
+			if (0 != memcmp(dest_ref[i], dest_ptrs[i], size)) {
+				printf("Fail rand " xstr(FUNCTION_UNDER_TEST)
+				       " test%d ualign len=%d\n", i, size);
+				dump_matrix(buffs, vector, TEST_SOURCES);
+				printf("dprod_base:");
+				dump(dest_ref[i], 25);
+				printf("dprod_dut:");
+				dump(dest_ptrs[i], 25);
+				return -1;
+			}
+		}
+
+		putchar('.');
+
+	}
+
+	printf("Pass\n");
+	return 0;
+
+}

--- a/erasure_code/loongarch64/gf_vect_mul_lasx.c
+++ b/erasure_code/loongarch64/gf_vect_mul_lasx.c
@@ -1,0 +1,126 @@
+/**********************************************************************
+  Copyright(c) 2022 Loongson Tech All rights reserved.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions
+  are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in
+      the documentation and/or other materials provided with the
+      distribution.
+    * Neither the name of Intel Corporation nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+**********************************************************************/
+
+#include <lasxintrin.h>
+
+int gf_vect_mul_lasx(int len, unsigned char *a, unsigned char *src, unsigned char *dest)
+{
+	int i;
+
+	int block_count = len >> 5;
+	int remain = len - (block_count << 5);
+	int buf_offset = 0;
+
+	__m256i block, high_idx, low_idx;
+	__m256i high_elem, low_elem;
+       	__m256i	high_val, low_val;
+	__m256i res;
+
+	unsigned long index, tmp;
+	unsigned char sval;
+
+	for (i = 0; i < block_count; ++i) {
+		/* read one block from one buf to update one row */
+
+		buf_offset = i << 5;
+
+		// fetch one block from one buf into a vector variable,
+		// the block size is 32 bytes
+		block = __lasx_xvldx(src, buf_offset);
+
+		// get low indexes
+		low_idx = __lasx_xvandi_b(block, 0x0F);
+
+		// get high indexes: shift right 4 bits and add 0x10,
+		// which can index {0x10, ..., 0x1F}
+		high_idx = __lasx_xvori_b(__lasx_xvsrli_b(block, 4), 0x10);
+
+		/* =================== for row 0 =================== */
+		// fetch one element from gftbls, which is 32 bytes
+		low_elem = __lasx_xvld(a, 0);
+		high_elem = low_elem;
+
+		// duplicate low part
+		low_elem = __lasx_xvpermi_d(low_elem, 0x44);
+
+		// duplicate high part
+		high_elem = __lasx_xvpermi_d(high_elem, 0xEE);
+
+		// pick by low_idx
+		low_val = __lasx_xvshuf_b(low_elem, low_elem, low_idx);
+
+		// pick by high_idx
+		high_val = __lasx_xvshuf_b(high_elem, high_elem, high_idx);
+
+		// accumulation on GF(2^8)
+		res = __lasx_xvxor_v(low_val, high_val);
+
+		__lasx_xvstx(res, dest, buf_offset);
+	}
+
+	if (remain == 0)
+		return 0;
+
+	// handle remain bytes
+	i = block_count << 5;
+	while (remain >= 8) {
+		index = *(unsigned long *)&src[i];
+
+		tmp = a[index & 0xF] ^ a[16 + ((index >> 4) & 0xF)];
+		index = index >> 8;
+		tmp |= (unsigned long)(a[index & 0xF] ^ a[16 + ((index >> 4) & 0xF)]) << 8;
+		index = index >> 8;
+		tmp |= (unsigned long)(a[index & 0xF] ^ a[16 + ((index >> 4) & 0xF)]) << 16;
+		index = index >> 8;
+		tmp |= (unsigned long)(a[index & 0xF] ^ a[16 + ((index >> 4) & 0xF)]) << 24;
+		index = index >> 8;
+		tmp |= (unsigned long)(a[index & 0xF] ^ a[16 + ((index >> 4) & 0xF)]) << 32;
+		index = index >> 8;
+		tmp |= (unsigned long)(a[index & 0xF] ^ a[16 + ((index >> 4) & 0xF)]) << 40;
+		index = index >> 8;
+		tmp |= (unsigned long)(a[index & 0xF] ^ a[16 + ((index >> 4) & 0xF)]) << 48;
+		index = index >> 8;
+		tmp |= (unsigned long)(a[index & 0xF] ^ a[16 + ((index >> 4) & 0xF)]) << 56;
+
+		*(unsigned long *)&dest[i] = tmp;
+
+		i += sizeof(unsigned long);
+		remain -= sizeof(unsigned long);
+	}
+
+	if (remain == 0)
+		return 0;
+
+	for (; i < len; i++) {
+		sval = src[i];
+		dest[i] = a[sval & 0xF] ^ a[16 + (sval >> 4)];
+	}
+
+	return 0;
+}

--- a/erasure_code/loongarch64/gf_vect_mul_lasx_test.c
+++ b/erasure_code/loongarch64/gf_vect_mul_lasx_test.c
@@ -1,0 +1,159 @@
+/**********************************************************************
+  Copyright(c) 2011-2015 Intel Corporation All rights reserved.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions
+  are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in
+      the documentation and/or other materials provided with the
+      distribution.
+    * Neither the name of Intel Corporation nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+**********************************************************************/
+
+#include <stdio.h>
+#include <stdlib.h>
+#include "erasure_code.h"
+#include "ec_loongarch64.h"
+
+#define TEST_SIZE (128*1024+31)
+
+typedef unsigned char u8;
+
+int main(int argc, char *argv[])
+{
+	int i;
+	u8 *buff1, *buff2, *buff3, gf_const_tbl[64], a = 2;
+	int tsize;
+	int align, size;
+	unsigned char *efence_buff1;
+	unsigned char *efence_buff2;
+	unsigned char *efence_buff3;
+
+	printf("gf_vect_mul_test: ");
+
+	gf_vect_mul_init(a, gf_const_tbl);
+
+	buff1 = (u8 *) malloc(TEST_SIZE);
+	buff2 = (u8 *) malloc(TEST_SIZE);
+	buff3 = (u8 *) malloc(TEST_SIZE);
+
+	if (NULL == buff1 || NULL == buff2 || NULL == buff3) {
+		printf("buffer alloc error\n");
+		return -1;
+	}
+	// Fill with rand data
+	for (i = 0; i < TEST_SIZE; i++)
+		buff1[i] = rand();
+
+	gf_vect_mul_lasx(TEST_SIZE, gf_const_tbl, buff1, buff2);
+
+	for (i = 0; i < TEST_SIZE; i++) {
+		if (gf_mul(a, buff1[i]) != buff2[i]) {
+			printf("fail at %d, 0x%x x 2 = 0x%x (0x%x)\n", i,
+			       buff1[i], buff2[i], gf_mul(2, buff1[i]));
+			return -1;
+		}
+	}
+
+	gf_vect_mul_base(TEST_SIZE, gf_const_tbl, buff1, buff3);
+
+	// Check reference function
+	for (i = 0; i < TEST_SIZE; i++) {
+		if (buff2[i] != buff3[i]) {
+			printf("fail at %d, 0x%x x 0x%d = 0x%x (0x%x)\n",
+			       i, a, buff1[i], buff2[i], gf_mul(a, buff1[i]));
+			return -1;
+		}
+	}
+
+	for (i = 0; i < TEST_SIZE; i++)
+		buff1[i] = rand();
+
+	// Check each possible constant
+	for (a = 0; a != 255; a++) {
+		gf_vect_mul_init(a, gf_const_tbl);
+		gf_vect_mul_lasx(TEST_SIZE, gf_const_tbl, buff1, buff2);
+
+		for (i = 0; i < TEST_SIZE; i++)
+			if (gf_mul(a, buff1[i]) != buff2[i]) {
+				printf("fail at %d, 0x%x x %d = 0x%x (0x%x)\n",
+				       i, a, buff1[i], buff2[i], gf_mul(2, buff1[i]));
+				return -1;
+			}
+		putchar('.');
+	}
+
+	// Check buffer len
+	for (tsize = TEST_SIZE; tsize > 0; tsize -= 32) {
+		a = rand();
+		gf_vect_mul_init(a, gf_const_tbl);
+		gf_vect_mul_lasx(tsize, gf_const_tbl, buff1, buff2);
+
+		for (i = 0; i < tsize; i++)
+			if (gf_mul(a, buff1[i]) != buff2[i]) {
+				printf("fail at %d, 0x%x x %d = 0x%x (0x%x)\n",
+				       i, a, buff1[i], buff2[i], gf_mul(2, buff1[i]));
+				return -1;
+			}
+		if (0 == tsize % (32 * 8)) {
+			putchar('.');
+			fflush(0);
+		}
+	}
+
+	// Run tests at end of buffer for Electric Fence
+	align = 32;
+	a = 2;
+
+	gf_vect_mul_init(a, gf_const_tbl);
+	for (size = 0; size < TEST_SIZE; size += align) {
+		// Line up TEST_SIZE from end
+		efence_buff1 = buff1 + size;
+		efence_buff2 = buff2 + size;
+		efence_buff3 = buff3 + size;
+
+		gf_vect_mul_lasx(TEST_SIZE - size, gf_const_tbl, efence_buff1, efence_buff2);
+
+		for (i = 0; i < TEST_SIZE - size; i++)
+			if (gf_mul(a, efence_buff1[i]) != efence_buff2[i]) {
+				printf("fail at %d, 0x%x x 2 = 0x%x (0x%x)\n",
+				       i, efence_buff1[i], efence_buff2[i],
+				       gf_mul(2, efence_buff1[i]));
+				return 1;
+			}
+
+		gf_vect_mul_base(TEST_SIZE - size, gf_const_tbl, efence_buff1, efence_buff3);
+
+		// Check reference function
+		for (i = 0; i < TEST_SIZE - size; i++)
+			if (efence_buff2[i] != efence_buff3[i]) {
+				printf("fail at %d, 0x%x x 0x%d = 0x%x (0x%x)\n",
+				       i, a, efence_buff2[i], efence_buff3[i],
+				       gf_mul(2, efence_buff1[i]));
+				return 1;
+			}
+
+		putchar('.');
+	}
+
+	printf(" done: Pass\n");
+	fflush(0);
+	return 0;
+}

--- a/igzip/Makefile.am
+++ b/igzip/Makefile.am
@@ -39,6 +39,7 @@ lsrc        += 	igzip/igzip.c \
 lsrc_base_aliases += igzip/igzip_base_aliases.c igzip/proc_heap_base.c
 lsrc_x86_32       += igzip/igzip_base_aliases.c igzip/proc_heap_base.c
 lsrc_ppc64le      += igzip/igzip_base_aliases.c igzip/proc_heap_base.c
+lsrc_loongarch64  += igzip/igzip_base_aliases.c igzip/proc_heap_base.c
 
 lsrc_aarch64 +=	igzip/aarch64/igzip_inflate_multibinary_arm64.S  \
 		igzip/aarch64/igzip_multibinary_arm64.S	\

--- a/mem/Makefile.am
+++ b/mem/Makefile.am
@@ -33,6 +33,7 @@ lsrc        += 	mem/mem_zero_detect_base.c
 
 lsrc_base_aliases += mem/mem_zero_detect_base_aliases.c
 lsrc_ppc64le      += mem/mem_zero_detect_base_aliases.c
+lsrc_loongarch64  += mem/mem_zero_detect_base_aliases.c
 
 lsrc_x86_64 += 	mem/mem_zero_detect_avx.asm \
 		mem/mem_zero_detect_sse.asm \

--- a/raid/Makefile.am
+++ b/raid/Makefile.am
@@ -33,6 +33,7 @@ lsrc        += 	raid/raid_base.c
 
 lsrc_base_aliases += raid/raid_base_aliases.c
 lsrc_ppc64le      += raid/raid_base_aliases.c
+lsrc_loongarch64  += raid/raid_base_aliases.c
 
 lsrc_x86_64 += \
 		raid/xor_gen_sse.asm \


### PR DESCRIPTION
Use 256 bits lasx intrinsics of LoongArch to implement ec_encode_data(), ec_encode_data_update(),
gf_vect_dot_prod(), gf_vect_mad(), gf_vect_mul()

Signed-off-by: Min Zhou <zhoumin@loongson.cn>

@bibo-mao